### PR TITLE
Add Travis CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ion-tests"]
+	path = ion-tests
+	url = https://github.com/amzn/ion-tests.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ion-tests"]
-	path = ion-tests
-	url = git@github.com:amzn/ion-tests.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk:
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk11
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ jdk:
   - openjdk9
   - openjdk10
   - openjdk11
-  - oraclejdk8
+  # not supported by travis: https://github.com/travis-ci/travis-ci/issues/10290 
+  # - oraclejdk8
   - oraclejdk9
   - oraclejdk11
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ val stockItems = ion.newReader(stockItemsIonText).use { reader ->
 
 ## Building
 
-Pull in the `ion-tests` repository:
+Pull in the `ion-tests` git submodule:
 
 ``` 
 git submodule update --init

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ val stockItems = ion.newReader(stockItemsIonText).use { reader ->
 }.asSequence().toList()
 ```
 
+## Building
+
+Pull in the `ion-tests` repository:
+
+``` 
+git submodule update --init
+``
+
+Then run the gradle wrapper:
+
+```
+./gradlew build
+```
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,6 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 }
 
-// Automatically pull in the ion-tests git submodule (so we don't have to remember to do it separately,
-// also helps with Travis, etc)
-task submodulesUpdate(type:Exec) {
-    description 'Updates (and inits) git submodules'
-    commandLine 'git', 'submodule', 'update', '--init', '--recursive'
-    group 'Build Setup'
-}
-
 test {
     useJUnitPlatform()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,10 @@
+
+signing.keyId=EMPTY
+signing.password=EMPTY
+signing.secretKeyRingFile=EMPTY
+
+ossrhUsername=EMPTY
+ossrhPassword=EMPTY
+
+
+


### PR DESCRIPTION
Had to re-create the `ion-tests` submodule since I'd originally created it with the SSH URL instead of the HTTPS URL.

Removed the attempt I added to execute `git submodules update --init --recursive` in `build.gradle` since it wasn't working and I found out that `travis` pulls in git submodules by default.

Also added a `gradle.properties` file which is now required since it defines variables used by the publishing plugin.  (With "EMPTY", values to be specified prior to publishing.)