### PR TITLE
Add ElementType

### DIFF
--- a/src/com/amazon/ionelement/api/ElementType.kt
+++ b/src/com/amazon/ionelement/api/ElementType.kt
@@ -1,0 +1,91 @@
+package com.amazon.ionelement.api
+
+import com.amazon.ion.IonType
+
+/**
+ * Indicates the type of the Ion value represented by an instance of [IonElement].
+ *
+ * [ElementType] has all the same members as `ion-java`'s [IonType] except for [IonType.DATAGRAM] because [IonElement]
+ * has no notion of datagrams.  It also exposes [isText], [isContainer] and [isLob] as properties instead of as static
+ * functions.
+ */
+enum class ElementType(
+    /** True if the current [ElementType] is [STRING] or [SYMBOL]. */
+    val isText: Boolean,
+
+    /**
+     * True if the current [ElementType] is [LIST] or [SEXP].
+     *
+     * TODO: during the implementation of:
+     * - https://github.com/amzn/ion-element-kotlin/issues/11
+     * - https://github.com/amzn/ion-element-kotlin/issues/12
+     * The term "container" may change.
+     */
+    val isContainer: Boolean,
+
+    /** True if the current [ElementType] is [CLOB] or [BLOB]. */
+    val isLob: Boolean
+) {
+    // Other types
+    NULL(false, false, false),
+    BOOL(false, false, false),
+    INT(false, false, false),
+    FLOAT(false, false, false),
+    DECIMAL(false, false, false),
+    TIMESTAMP(false, false, false),
+
+    // String-valued types
+    SYMBOL(true, false, false),
+    STRING(true, false, false),
+
+    // Binary-valued types
+    CLOB(false, false, true),
+    BLOB(false, false, true),
+
+    // Container types
+    LIST(false, true, false),
+    SEXP(false, true, false),
+
+    // TODO: with https://github.com/amzn/ion-element-kotlin/issues/12 it may be appropriate to consider structs to be containers.
+    STRUCT(false, false, false);
+
+    /** Converts this [ElementType] to [IonType]. */
+    fun toIonType() = when(this) {
+        NULL -> IonType.NULL
+        BOOL -> IonType.BOOL
+        INT -> IonType.INT
+        FLOAT -> IonType.FLOAT
+        DECIMAL -> IonType.DECIMAL
+        TIMESTAMP -> IonType.TIMESTAMP
+        SYMBOL -> IonType.SYMBOL
+        STRING -> IonType.STRING
+        CLOB -> IonType.CLOB
+        BLOB -> IonType.BLOB
+        LIST -> IonType.LIST
+        SEXP -> IonType.SEXP
+        STRUCT -> IonType.STRUCT
+    }
+}
+
+/**
+ * Converts the receiver [IonType] to [ElementType].
+ *
+ * @throws [IllegalStateException] if the receiver is [IonType.DATAGRAM] because [IonElement] has no notion of
+ * datagrams.
+ */
+fun IonType.toElementType() = when(this) {
+    IonType.NULL -> ElementType.NULL
+    IonType.BOOL -> ElementType.BOOL
+    IonType.INT -> ElementType.INT
+    IonType.FLOAT -> ElementType.FLOAT
+    IonType.DECIMAL -> ElementType.DECIMAL
+    IonType.TIMESTAMP -> ElementType.TIMESTAMP
+    IonType.SYMBOL -> ElementType.SYMBOL
+    IonType.STRING -> ElementType.STRING
+    IonType.CLOB -> ElementType.CLOB
+    IonType.BLOB -> ElementType.BLOB
+    IonType.LIST -> ElementType.LIST
+    IonType.SEXP -> ElementType.SEXP
+    IonType.STRUCT -> ElementType.STRUCT
+    IonType.DATAGRAM -> error("IonType.DATAGRAM has no ElementType equivalent")
+}

--- a/src/com/amazon/ionelement/api/Ion.kt
+++ b/src/com/amazon/ionelement/api/Ion.kt
@@ -33,7 +33,6 @@ import com.amazon.ionelement.impl.StructIonElementImpl
 import com.amazon.ionelement.impl.SymbolIonElement
 import com.amazon.ionelement.impl.TimestampIonElement
 import com.amazon.ion.Decimal
-import com.amazon.ion.IonType
 import com.amazon.ion.Timestamp
 import java.math.BigInteger
 
@@ -43,43 +42,43 @@ import java.math.BigInteger
 
 /** Creates an [IonElement] that represents an Ion `null.null` or a typed `null`.*/
 @JvmOverloads
-fun ionNull(ionType: IonType = IonType.NULL): IonElement = ALL_NULLS.getValue(ionType)
+fun ionNull(elementType: ElementType = ElementType.NULL): IonElement = ALL_NULLS.getValue(elementType)
 
 /** Creates an [IonElement] that represents an Ion `symbol`.*/
 fun ionString(s: String?): IonElement =
-    s?.let { StringIonElement(it) } ?: ionNull(IonType.STRING)
+    s?.let { StringIonElement(it) } ?: ionNull(ElementType.STRING)
 
 /** Creates an [IonElement] that represents an Ion `symbol`.*/
 fun ionSymbol(s: String?): IonElement =
-    s?.let { SymbolIonElement(it) } ?: ionNull(IonType.SYMBOL)
+    s?.let { SymbolIonElement(it) } ?: ionNull(ElementType.SYMBOL)
 
 /** Creates an IonElement that represents an Ion `timestamp`.*/
 fun ionTimestamp(s: String?): IonElement =
-    s?.let { TimestampIonElement(Timestamp.valueOf(s)) } ?: ionNull(IonType.TIMESTAMP)
+    s?.let { TimestampIonElement(Timestamp.valueOf(s)) } ?: ionNull(ElementType.TIMESTAMP)
 
 /** Creates an [IonElement] that represents an Ion `timestamp`.*/
 fun ionTimestamp(timestamp: Timestamp?): IonElement =
-    timestamp?.let { TimestampIonElement(timestamp) } ?: ionNull(IonType.TIMESTAMP)
+    timestamp?.let { TimestampIonElement(timestamp) } ?: ionNull(ElementType.TIMESTAMP)
 
 /** Creates an [IonElement] that represents an Ion `int`.*/
 fun ionInt(l: Long?): IonElement =
-    l?.let { IntIonElement(it) } ?: ionNull(IonType.INT)
+    l?.let { IntIonElement(it) } ?: ionNull(ElementType.INT)
 
 /** Creates an [IonElement] that represents an Ion `BitInteger`.*/
 fun ionInt(bigInt: BigInteger?): IonElement =
-    bigInt?.let { BigIntIonElement(it) } ?: ionNull(IonType.INT)
+    bigInt?.let { BigIntIonElement(it) } ?: ionNull(ElementType.INT)
 
 /** Creates an [IonElement] that represents an Ion `bool`.*/
 fun ionBool(b: Boolean?): IonElement =
-    b?.let { BoolIonElement(it) } ?: ionNull(IonType.BOOL)
+    b?.let { BoolIonElement(it) } ?: ionNull(ElementType.BOOL)
 
 /** Creates an [IonElement] that represents an Ion `float`.*/
 fun ionFloat(d: Double?): IonElement =
-    d?.let { FloatIonElement(it) } ?: ionNull(IonType.FLOAT)
+    d?.let { FloatIonElement(it) } ?: ionNull(ElementType.FLOAT)
 
 /** Creates an [IonElement] that represents an Ion `decimall`.*/
 fun ionDecimal(bigDecimal: Decimal?): IonElement =
-    bigDecimal?.let { DecimalIonElement(bigDecimal) } ?: ionNull(IonType.DECIMAL)
+    bigDecimal?.let { DecimalIonElement(bigDecimal) } ?: ionNull(ElementType.DECIMAL)
 
 /**
  * Creates an [IonElement] that represents an Ion `blob`.
@@ -87,7 +86,7 @@ fun ionDecimal(bigDecimal: Decimal?): IonElement =
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
 fun ionBlob(bytes: ByteArray?): IonElement =
-    bytes?.let { BlobIonElement(bytes.clone()) } ?: ionNull(IonType.BLOB)
+    bytes?.let { BlobIonElement(bytes.clone()) } ?: ionNull(ElementType.BLOB)
 
 fun emptyBlob(): IonElement = EMPTY_BLOB
 
@@ -97,7 +96,7 @@ fun emptyBlob(): IonElement = EMPTY_BLOB
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
 fun ionClob(bytes: ByteArray?): IonElement =
-    bytes?.let { ClobIonElement(bytes.clone()) } ?: ionNull(IonType.CLOB)
+    bytes?.let { ClobIonElement(bytes.clone()) } ?: ionNull(ElementType.CLOB)
 
 fun emptyClob(): IonElement = EMPTY_CLOB
 
@@ -159,4 +158,4 @@ private val EMPTY_BLOB = BlobIonElement(ByteArray(0))
 private val EMPTY_CLOB = ClobIonElement(ByteArray(0))
 
 // Memoized instances of all of our null values.
-private val ALL_NULLS = IonType.values().map { it to NullIonElement(it) }.toMap()
+private val ALL_NULLS = ElementType.values().map { it to NullIonElement(it) }.toMap()

--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -30,20 +30,20 @@ import java.math.BigInteger
  *
  * The table below shows which properties should be used to access the raw values for each of the given [IonType]s.
  *
- * | When the IonType is... | The Valid Accessors Are (others will throw [IonElectrolyteException])      |
- * |------------------------|----------------------------------------------------------------------------|
- * | [IonType.NULL]         | ...any function with the `OrNull` suffix.                                  |
- * | [IonType.BOOL]         | [booleanValue], [booleanValueOrNull]                                       |
- * | [IonType.INT]          | [longValue], [longValueOrNull], [bigIntegerValue], [bigIntegerValueOrNull] |
- * | [IonType.STRING]       | [textValue], [textValueOrNull], [stringValue], [stringValueOrNull]         |
- * | [IonType.SYMBOL]       | [textValue], [textValueOrNull], [symbolValue], [symbolValueOrNull]         |
- * | [IonType.DECIMAL]      | [decimalValue], [decimalValueOrNull]                                       |
- * | [IonType.TIMESTAMP]    | [timestampValue], [timestampValueOrNull]                                   |
- * | [IonType.CLOB]         | [bytesValue], [bytesValueOrNull], [clobValue], [clobValueOrNull]           |
- * | [IonType.BLOB]         | [bytesValue], [bytesValueOrNull], [blobValue], [blobValueOrNull]           |
- * | [IonType.LIST]         | [containerValue], [containerValueOrNull], [listValue], [listValueOrNull]   |
- * | [IonType.SEXP]         | [containerValue], [containerValueOrNull], [sexpValue], [sexpValueOrNull]   |
- * | [IonType.STRUCT]       | [structValue], [structValueOrNull]                                         |
+ * | When the [ElementType] is... | The Valid Accessors Are (others will throw [IonElectrolyteException])      |
+ * |------------------------------|----------------------------------------------------------------------------|
+ * | [ElementType.NULL]           | ...any function with the `OrNull` suffix.                                  |
+ * | [ElementType.BOOL]           | [booleanValue], [booleanValueOrNull]                                       |
+ * | [ElementType.INT]            | [longValue], [longValueOrNull], [bigIntegerValue], [bigIntegerValueOrNull] |
+ * | [ElementType.STRING]         | [textValue], [textValueOrNull], [stringValue], [stringValueOrNull]         |
+ * | [ElementType.SYMBOL]         | [textValue], [textValueOrNull], [symbolValue], [symbolValueOrNull]         |
+ * | [ElementType.DECIMAL]        | [decimalValue], [decimalValueOrNull]                                       |
+ * | [ElementType.TIMESTAMP]      | [timestampValue], [timestampValueOrNull]                                   |
+ * | [ElementType.CLOB]           | [bytesValue], [bytesValueOrNull], [clobValue], [clobValueOrNull]           |
+ * | [ElementType.BLOB]           | [bytesValue], [bytesValueOrNull], [blobValue], [blobValueOrNull]           |
+ * | [ElementType.LIST]           | [containerValue], [containerValueOrNull], [listValue], [listValueOrNull]   |
+ * | [ElementType.SEXP]           | [containerValue], [containerValueOrNull], [sexpValue], [sexpValueOrNull]   |
+ * | [ElementType.STRUCT]         | [structValue], [structValueOrNull]                                         |
  *
  * These accessors can be chained together in a way that allows data to be mapped to domain objects very easily.  The
  * main benefit of this approach is that data is automatically checked to ensure it's the proper data type and
@@ -99,7 +99,7 @@ import java.math.BigInteger
 interface IonElement {
 
     /** The Ion data type of the current node.  */
-    val type: IonType
+    val type: ElementType
 
     /** This element's Ion metadata. */
     val metas: MetaContainer
@@ -144,97 +144,97 @@ interface IonElement {
     val booleanValue: Boolean get() = handleNull { booleanValueOrNull }
 
     /** See [IonElement]. */
-    val booleanValueOrNull: Boolean? get() = expectNullOr(IonType.BOOL).run { null }
+    val booleanValueOrNull: Boolean? get() = expectNullOr(ElementType.BOOL).run { null }
 
     /** See [IonElement]. */
     val longValue: Long get() = handleNull { longValueOrNull }
 
     /** See [IonElement]. */
-    val longValueOrNull: Long? get() = expectNullOr(IonType.INT).run { null }
+    val longValueOrNull: Long? get() = expectNullOr(ElementType.INT).run { null }
 
     /** See [IonElement]. */
     val bigIntegerValue: BigInteger get() = handleNull { bigIntegerValueOrNull }
 
     /** See [IonElement]. */
-    val bigIntegerValueOrNull: BigInteger? get() = expectNullOr(IonType.INT).run { null }
+    val bigIntegerValueOrNull: BigInteger? get() = expectNullOr(ElementType.INT).run { null }
 
     /** See [IonElement]. */
     val textValue: String get() = handleNull { textValueOrNull }
 
     /** See [IonElement]. */
-    val textValueOrNull: String? get() = expectNullOr(IonType.STRING, IonType.SYMBOL).run { null }
+    val textValueOrNull: String? get() = expectNullOr(ElementType.STRING, ElementType.SYMBOL).run { null }
 
     /** See [IonElement]. */
     val stringValue: String get() = handleNull { stringValueOrNull }
 
     /** See [IonElement]. */
-    val stringValueOrNull: String? get() = expectNullOr(IonType.STRING).run { null }
+    val stringValueOrNull: String? get() = expectNullOr(ElementType.STRING).run { null }
 
     /** See [IonElement]. */
     val symbolValue: String get() = handleNull { symbolValueOrNull }
 
     /** See [IonElement]. */
-    val symbolValueOrNull: String? get() = expectNullOr(IonType.SYMBOL).run { null }
+    val symbolValueOrNull: String? get() = expectNullOr(ElementType.SYMBOL).run { null }
 
     /** See [IonElement]. */
     val decimalValue: Decimal get() = handleNull { decimalValueOrNull }
 
     /** See [IonElement]. */
-    val decimalValueOrNull: Decimal? get() = expectNullOr(IonType.DECIMAL).run { null }
+    val decimalValueOrNull: Decimal? get() = expectNullOr(ElementType.DECIMAL).run { null }
 
     /** See [IonElement]. */
     val doubleValue: Double get()  = handleNull { doubleValueOrNull }
 
     /** See [IonElement]. */
-    val doubleValueOrNull: Double? get() = expectNullOr(IonType.FLOAT).run { null }
+    val doubleValueOrNull: Double? get() = expectNullOr(ElementType.FLOAT).run { null }
 
     /** See [IonElement]. */
     val timestampValue: Timestamp get() = handleNull { timestampValueOrNull }
 
     /** See [IonElement]. */
-    val timestampValueOrNull: Timestamp? get() = expectNullOr(IonType.TIMESTAMP).run { null }
+    val timestampValueOrNull: Timestamp? get() = expectNullOr(ElementType.TIMESTAMP).run { null }
 
     /** See [IonElement]. */
     val bytesValue: IonByteArray get() = handleNull { bytesValueOrNull }
 
     /** See [IonElement]. */
-    val bytesValueOrNull: IonByteArray? get() = expectNullOr(IonType.BLOB, IonType.CLOB).run { null }
+    val bytesValueOrNull: IonByteArray? get() = expectNullOr(ElementType.BLOB, ElementType.CLOB).run { null }
 
     /** See [IonElement]. */
     val blobValue: IonByteArray get() = handleNull { blobValueOrNull }
 
     /** See [IonElement]. */
-    val blobValueOrNull: IonByteArray? get() = expectNullOr(IonType.BLOB).run { null }
+    val blobValueOrNull: IonByteArray? get() = expectNullOr(ElementType.BLOB).run { null }
 
     /** See [IonElement]. */
     val clobValue: IonByteArray get() = handleNull { clobValueOrNull }
 
     /** See [IonElement]. */
-    val clobValueOrNull: IonByteArray? get() = expectNullOr(IonType.CLOB).run { null }
+    val clobValueOrNull: IonByteArray? get() = expectNullOr(ElementType.CLOB).run { null }
 
     /** See [IonElement]. */
     val containerValue: IonElementContainer get() = handleNull { containerValueOrNull }
 
     /** See [IonElement]. */
-    val containerValueOrNull: IonElementContainer? get() = expectNullOr(IonType.LIST, IonType.SEXP).run { null }
+    val containerValueOrNull: IonElementContainer? get() = expectNullOr(ElementType.LIST, ElementType.SEXP).run { null }
 
     /** See [IonElement]. */
     val listValue: IonElementContainer get() = handleNull { listValueOrNull }
 
     /** See [IonElement]. */
-    val listValueOrNull: IonElementContainer? get() = expectNullOr(IonType.LIST).run { null }
+    val listValueOrNull: IonElementContainer? get() = expectNullOr(ElementType.LIST).run { null }
 
     /** See [IonElement]. */
     val sexpValue: IonElementContainer get() = handleNull { sexpValueOrNull }
 
     /** See [IonElement]. */
-    val sexpValueOrNull: IonElementContainer? get() = expectNullOr(IonType.SEXP).run { null }
+    val sexpValueOrNull: IonElementContainer? get() = expectNullOr(ElementType.SEXP).run { null }
 
     /** See [IonElement]. */
     val structValue: StructIonElement get() = handleNull { structValueOrNull }
 
     /** See [IonElement]. */
-    val structValueOrNull: StructIonElement? get() = expectNullOr(IonType.STRUCT).run { null }
+    val structValueOrNull: StructIonElement? get() = expectNullOr(ElementType.STRUCT).run { null }
 
 
     /** Writes the current Ion element to the specified [IonWriter]. */
@@ -243,9 +243,9 @@ interface IonElement {
     /** Converts the current element to Ion text. */
     override fun toString(): String
 
-    /** Throws an [IonElectrolyteException] if the current instance was not [IonType.NULL] or in [expectedTypes]. */
-    private fun expectNullOr(vararg expectedTypes: IonType) {
-        if (this.type != IonType.NULL && !expectedTypes.contains(type)) {
+    /** Throws an [IonElectrolyteException] if the current instance was not [ElementType.NULL] or in [expectedTypes]. */
+    private fun expectNullOr(vararg expectedTypes: ElementType) {
+        if (this.type != ElementType.NULL && !expectedTypes.contains(type)) {
             ionError(this, "Expected Ion value of type ${expectedTypes.joinToString(",")} but found a value of type $type")
         }
     }

--- a/src/com/amazon/ionelement/impl/BigIntIonElement.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIonElement.kt
@@ -20,8 +20,8 @@ import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ionelement.api.ionError
 import com.amazon.ion.IntegerSize
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 import java.math.BigInteger
 
 internal class BigIntIonElement(
@@ -30,7 +30,7 @@ internal class BigIntIonElement(
     override val metas: MetaContainer = emptyMetaContainer()
 ) : IonElementBase() {
 
-    override val type: IonType get() = IonType.INT
+    override val type: ElementType get() = ElementType.INT
 
     override val integerSize: IntegerSize get() = IntegerSize.BIG_INTEGER
 

--- a/src/com/amazon/ionelement/impl/BlobIonElement.kt
+++ b/src/com/amazon/ionelement/impl/BlobIonElement.kt
@@ -19,8 +19,8 @@ import com.amazon.ionelement.api.IonByteArray
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 
 internal class BlobIonElement(
     override val bytes: ByteArray,
@@ -35,5 +35,5 @@ internal class BlobIonElement(
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =
         BlobIonElement(bytes, annotations, metas)
 
-    override val type: IonType get() = IonType.BLOB
+    override val type: ElementType get() = ElementType.BLOB
 }

--- a/src/com/amazon/ionelement/impl/BoolIonElement.kt
+++ b/src/com/amazon/ionelement/impl/BoolIonElement.kt
@@ -18,15 +18,15 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 
 internal class BoolIonElement(
     val value: Boolean,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ): IonElementBase() {
-    override val type: IonType get() = IonType.BOOL
+    override val type: ElementType get() = ElementType.BOOL
     override val booleanValueOrNull: Boolean get() = value
 
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =

--- a/src/com/amazon/ionelement/impl/ClobIonElement.kt
+++ b/src/com/amazon/ionelement/impl/ClobIonElement.kt
@@ -19,8 +19,8 @@ import com.amazon.ionelement.api.IonByteArray
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 
 internal class ClobIonElement(
     override val bytes: ByteArray,
@@ -33,5 +33,5 @@ internal class ClobIonElement(
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =
         ClobIonElement(bytes, annotations, metas)
 
-    override val type: IonType get() = IonType.CLOB
+    override val type: ElementType get() = ElementType.CLOB
 }

--- a/src/com/amazon/ionelement/impl/DecimalIonElement.kt
+++ b/src/com/amazon/ionelement/impl/DecimalIonElement.kt
@@ -19,15 +19,15 @@ import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ion.Decimal
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 
 internal class DecimalIonElement(
     val value: Decimal,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ) : IonElementBase() {
-    override val type get() = IonType.DECIMAL
+    override val type get() = ElementType.DECIMAL
     override val decimalValueOrNull: Decimal get() = value
 
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =

--- a/src/com/amazon/ionelement/impl/FloatIonElement.kt
+++ b/src/com/amazon/ionelement/impl/FloatIonElement.kt
@@ -18,8 +18,8 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 import kotlin.math.sign
 
 internal class FloatIonElement(
@@ -27,7 +27,7 @@ internal class FloatIonElement(
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ) : IonElementBase() {
-    override val type: IonType get() = IonType.FLOAT
+    override val type: ElementType get() = ElementType.FLOAT
     override val doubleValueOrNull: Double get() = value
 
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =

--- a/src/com/amazon/ionelement/impl/IntIonElement.kt
+++ b/src/com/amazon/ionelement/impl/IntIonElement.kt
@@ -19,8 +19,8 @@ import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ion.IntegerSize
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 import java.math.BigInteger
 
 internal class IntIonElement(
@@ -28,7 +28,7 @@ internal class IntIonElement(
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ) : IonElementBase() {
-    override val type: IonType get() = IonType.INT
+    override val type: ElementType get() = ElementType.INT
     override val longValueOrNull: Long get() = value
     override val bigIntegerValueOrNull: BigInteger? get() = BigInteger.valueOf(value)
 

--- a/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -46,6 +46,7 @@ import com.amazon.ion.OffsetSpan
 import com.amazon.ion.SpanProvider
 import com.amazon.ion.TextSpan
 import com.amazon.ion.system.IonReaderBuilder
+import com.amazon.ionelement.api.toElementType
 
 class IonElementLoaderImpl(private val includeLocations: Boolean) : IonElementLoader {
     private inline fun <T> handleReaderException(ionReader: IonReader, crossinline block: () -> T): T {
@@ -126,7 +127,7 @@ class IonElementLoaderImpl(private val includeLocations: Boolean) : IonElementLo
 
             var element = when {
                 ionReader.type == IonType.DATAGRAM -> error("IonElementLoaderImpl does not know what to do with IonType.DATAGRAM")
-                ionReader.isNullValue -> ionNull(valueType)
+                ionReader.isNullValue -> ionNull(valueType.toElementType())
                 else -> {
                     when {
                         !IonType.isContainer(valueType) -> {

--- a/src/com/amazon/ionelement/impl/ListIonElementArray.kt
+++ b/src/com/amazon/ionelement/impl/ListIonElementArray.kt
@@ -19,14 +19,14 @@ import com.amazon.ionelement.api.IonElementContainer
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
+import com.amazon.ionelement.api.ElementType
 
 internal class ListIonElementArray (
     override val values: List<IonElement>,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ): OrderedIonElementArray(), IonElementContainer {
-    override val type: IonType get() = IonType.LIST
+    override val type: ElementType get() = ElementType.LIST
     override val listValueOrNull: IonElementContainer get() = this
 
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =

--- a/src/com/amazon/ionelement/impl/NullIonElement.kt
+++ b/src/com/amazon/ionelement/impl/NullIonElement.kt
@@ -18,11 +18,11 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 
 internal class NullIonElement(
-    override val type: IonType = IonType.NULL,
+    override val type: ElementType = ElementType.NULL,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ): IonElementBase() {
@@ -32,7 +32,7 @@ internal class NullIonElement(
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =
         NullIonElement(type, annotations, metas)
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeNull(type)
+    override fun writeContentTo(writer: IonWriter) = writer.writeNull(type.toIonType())
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/com/amazon/ionelement/impl/OrderedIonElementArray.kt
+++ b/src/com/amazon/ionelement/impl/OrderedIonElementArray.kt
@@ -30,7 +30,7 @@ internal abstract class OrderedIonElementArray(
     override val containerValueOrNull: IonElementContainer get() = this
 
     override fun writeContentTo(writer: IonWriter) {
-        writer.stepIn(type)
+        writer.stepIn(type.toIonType())
         values.forEach {
             it.writeTo(writer)
         }

--- a/src/com/amazon/ionelement/impl/SexpIonElementArray.kt
+++ b/src/com/amazon/ionelement/impl/SexpIonElementArray.kt
@@ -19,14 +19,14 @@ import com.amazon.ionelement.api.IonElementContainer
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
+import com.amazon.ionelement.api.ElementType
 
 internal class SexpIonElementArray (
     override val values: List<IonElement>,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ): OrderedIonElementArray(), IonElementContainer {
-    override val type: IonType get() = IonType.SEXP
+    override val type: ElementType get() = ElementType.SEXP
     override val sexpValueOrNull: IonElementContainer get() = this
 
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =

--- a/src/com/amazon/ionelement/impl/StringIonElement.kt
+++ b/src/com/amazon/ionelement/impl/StringIonElement.kt
@@ -18,15 +18,15 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 
 internal class StringIonElement(
     override val value: String,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ): TextIonElement() {
-    override val type: IonType get() = IonType.STRING
+    override val type: ElementType get() = ElementType.STRING
 
     override val stringValueOrNull: String get() = value
 

--- a/src/com/amazon/ionelement/impl/StructIonElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructIonElementImpl.kt
@@ -22,6 +22,7 @@ import com.amazon.ionelement.api.StructIonElement
 import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 
 internal class StructIonElementImpl(
     override val fields: List<IonStructField>,
@@ -31,7 +32,7 @@ internal class StructIonElementImpl(
 
     override fun iterator(): Iterator<IonStructField> = fields.iterator()
 
-    override val type: IonType get() = IonType.STRUCT
+    override val type: ElementType get() = ElementType.STRUCT
     override val structValueOrNull: StructIonElement get() = this
 
     override fun firstOrNull(fieldName: String): IonElement? =

--- a/src/com/amazon/ionelement/impl/SymbolIonElement.kt
+++ b/src/com/amazon/ionelement/impl/SymbolIonElement.kt
@@ -18,15 +18,15 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.ElementType
 
 internal class SymbolIonElement(
     override val value: String,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
 ): TextIonElement() {
-    override val type: IonType get() = IonType.SYMBOL
+    override val type: ElementType get() = ElementType.SYMBOL
 
     override val symbolValueOrNull: String get() = value
 

--- a/src/com/amazon/ionelement/impl/TimestampIonElement.kt
+++ b/src/com/amazon/ionelement/impl/TimestampIonElement.kt
@@ -18,9 +18,9 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
 import com.amazon.ion.Timestamp
+import com.amazon.ionelement.api.ElementType
 
 internal class TimestampIonElement(
     val value: Timestamp,
@@ -30,7 +30,7 @@ internal class TimestampIonElement(
     constructor(timestamp: String): this(Timestamp.valueOf(timestamp))
     override val timestampValueOrNull: Timestamp get() = value
 
-    override val type: IonType get() = IonType.TIMESTAMP
+    override val type: ElementType get() = ElementType.TIMESTAMP
     override fun clone(annotations: List<String>, metas: MetaContainer): IonElement =
         TimestampIonElement(value, annotations, metas)
 

--- a/test/com/amazon/ionelement/EquivalenceTests.kt
+++ b/test/com/amazon/ionelement/EquivalenceTests.kt
@@ -32,17 +32,15 @@ import com.amazon.ionelement.util.ArgumentsProviderBase
 import com.amazon.ionelement.util.randomIonElement
 import com.amazon.ionelement.util.randomSeed
 import com.amazon.ion.Decimal
-import com.amazon.ion.IonType
 import com.amazon.ion.Timestamp
+import com.amazon.ionelement.api.ElementType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 
 
-private val ALL_NULLS = IonType.values()
-    .filter { it != IonType.DATAGRAM }
-    .map { ionNull(it) }
+private val ALL_NULLS = ElementType.values().map { ionNull(it) }
 
 /** Expands a [EquivTestCase] by adding variations that include type annotations. */
 private fun List<EquivTestCase>.includeAnnotations(): List<EquivTestCase> {

--- a/test/com/amazon/ionelement/ValueAccessorTests.kt
+++ b/test/com/amazon/ionelement/ValueAccessorTests.kt
@@ -25,22 +25,23 @@ import com.amazon.ionelement.api.ionListOf
 import com.amazon.ionelement.api.ionSexpOf
 import com.amazon.ionelement.api.ionStructOf
 import com.amazon.ion.Decimal
-import com.amazon.ion.IonType
-import com.amazon.ion.IonType.BLOB
-import com.amazon.ion.IonType.BOOL
-import com.amazon.ion.IonType.CLOB
-import com.amazon.ion.IonType.DECIMAL
-import com.amazon.ion.IonType.TIMESTAMP
-import com.amazon.ion.IonType.FLOAT
-import com.amazon.ion.IonType.INT
-import com.amazon.ion.IonType.LIST
-import com.amazon.ion.IonType.NULL
-import com.amazon.ion.IonType.SEXP
-import com.amazon.ion.IonType.STRING
-import com.amazon.ion.IonType.STRUCT
-import com.amazon.ion.IonType.SYMBOL
-import com.amazon.ion.IonType.DATAGRAM
-import org.junit.jupiter.api.Assertions.*
+import com.amazon.ionelement.api.ElementType
+import com.amazon.ionelement.api.ElementType.NULL
+import com.amazon.ionelement.api.ElementType.BOOL
+import com.amazon.ionelement.api.ElementType.INT
+import com.amazon.ionelement.api.ElementType.FLOAT
+import com.amazon.ionelement.api.ElementType.DECIMAL
+import com.amazon.ionelement.api.ElementType.STRING
+import com.amazon.ionelement.api.ElementType.SYMBOL
+import com.amazon.ionelement.api.ElementType.TIMESTAMP
+import com.amazon.ionelement.api.ElementType.CLOB
+import com.amazon.ionelement.api.ElementType.BLOB
+import com.amazon.ionelement.api.ElementType.LIST
+import com.amazon.ionelement.api.ElementType.SEXP
+import com.amazon.ionelement.api.ElementType.STRUCT
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -51,11 +52,11 @@ class ValueAccessorTests {
     fun valueAccessorTests(tc: TestCase) {
 
         val element = createIonElementLoader().loadSingleElement(tc.ionText)
-        assertElementProperties(element, tc.ionType, tc.expectedValue)
+        assertElementProperties(element, tc.elementType, tc.expectedValue)
     }
 
     companion object {
-        data class TestCase(val ionText: String, val ionType: IonType, val expectedValue: Any?)
+        data class TestCase(val ionText: String, val elementType: ElementType, val expectedValue: Any?)
 
         @JvmStatic
         @Suppress("unused")
@@ -96,8 +97,8 @@ class ValueAccessorTests {
             TestCase("{ foo: 42 }", STRUCT, ionStructOf("foo" to ionInt(42))))
 
 
-        private fun assertElementProperties(element: IonElement, ionType: IonType, expectedValue: Any?) {
-            assertEquals(ionType, element.type)
+        private fun assertElementProperties(element: IonElement, elementType: ElementType, expectedValue: Any?) {
+            assertEquals(elementType, element.type)
 
             assertEquals(expectedValue == null, element.isNull)
             assertThrowsForWrongAccessorTypes(element)
@@ -144,7 +145,6 @@ class ValueAccessorTests {
                     LIST -> listOf(containerValue, containerValueOrNull, listValue, listValueOrNull)
                     SEXP -> listOf(containerValue, containerValueOrNull, sexpValue, sexpValueOrNull)
                     STRUCT -> listOf(structValue, structValueOrNull)
-                    DATAGRAM -> error("DATAGRAM not supported")
                 }
             }
 
@@ -192,7 +192,6 @@ class ValueAccessorTests {
                     LIST -> assertNull(listValueOrNull).also { assertNull(containerValueOrNull) }
                     SEXP -> assertNull(sexpValueOrNull).also { assertNull(containerValueOrNull) }
                     STRUCT -> assertNull(structValueOrNull)
-                    DATAGRAM -> error("IonType.DATAGRAM is unsupported")
                 }
             }
         }
@@ -237,7 +236,6 @@ class ValueAccessorTests {
                     LIST -> assertThrows<IonElectrolyteException> { listValue }.also { assertThrows<IonElectrolyteException> { containerValue } }
                     SEXP -> assertThrows<IonElectrolyteException> { sexpValue }.also { assertThrows<IonElectrolyteException> { containerValue } }
                     STRUCT -> assertThrows<IonElectrolyteException> { structValue }
-                    DATAGRAM -> error("IonType.DATAGRAM is unsupported")
                 }
             }
         }
@@ -304,9 +302,6 @@ class ValueAccessorTests {
                 if (type != STRUCT) {
                     assertThrows<IonElectrolyteException>("structValue") { structValue }
                     assertThrows<IonElectrolyteException>("structValueOrNull") { structValueOrNull }
-                }
-                if (type == DATAGRAM) {
-                    error("IonElement does not support IonType.DATAGRAM")
                 }
             }
         }

--- a/test/com/amazon/ionelement/util/randomElement.kt
+++ b/test/com/amazon/ionelement/util/randomElement.kt
@@ -28,8 +28,8 @@ import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.ionStructOf
 import com.amazon.ionelement.api.ionSymbol
 import com.amazon.ionelement.api.ionTimestamp
-import com.amazon.ion.IonType
 import com.amazon.ion.Timestamp
+import com.amazon.ionelement.api.ElementType
 import java.util.*
 
 val randomSeed = Random().nextLong()
@@ -44,8 +44,6 @@ private val MAX_TIMESTAMP_MILLIS = Timestamp.forSecond(1999, 12, 31, 23, 59, 59,
 private const val MAX_RANDOM_STRING_LENGTH = 25
 private const val CHARACTERS = "_____abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 private const val MAX_LOB_SIZE = 64
-
-private val ION_TYPES = IonType.values().filter { it != IonType.DATAGRAM }
 
 fun randomIonElement(): IonElement {
 
@@ -65,7 +63,7 @@ fun randomIonElement(): IonElement {
             // Generate a scalar value
             else -> {
                 when(random.nextInt(8)) {
-                    0 -> ionNull(ION_TYPES[random.nextInt(ION_TYPES.size)])
+                    0 -> ionNull(ElementType.values()[random.nextInt(ElementType.values().size)])
                     1 -> ionBool(random.nextBoolean())
                     2 -> ionInt(random.nextLong())
                     3 -> ionSymbol(randomString())


### PR DESCRIPTION
Also replace most uses of `IonType` with `ElementType`.

Implements #13.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
