### PR TITLE
Allow publishing to maven local without signing keys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ plugins {
 
 group = "com.amazon.ion"
 version = "0.2.0-SNAPSHOT"
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 repositories {
     mavenCentral()
@@ -136,6 +137,12 @@ signing {
     // This works because when not required, the signing task will be skipped
     // if signing.keyId, signing.password, signing.secretKeyRingFile, etc are
     // not present in gradle.properties.
-    required { !gradle.taskGraph.hasTask(":publishToMavenLocal") }
+    required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
     sign publishing.publications.maven
 }
+
+tasks.withType(Sign) {
+    onlyIf { isReleaseVersion }
+}
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,6 @@
 
-signing.keyId=EMPTY
-signing.password=EMPTY
-signing.secretKeyRingFile=EMPTY
 
+# Required for the maven publish plugin--these properties must be present even if they contain placeholder values.
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY
-
-
 


### PR DESCRIPTION
Previously it was not possible to publish to maven local without having the private signing key locally.  This change disables signing when publishing an on production a snapshot, allowing that.

I needed this for seeing the impact of [strongly-typed IonElement](https://github.com/amzn/ion-element-kotlin/pull/22) to [PIG](https://github.com/partiql/partiql-ir-generator/pull/12).  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
