### PR TITLE
Improve exception handling and rename IonElectrolyteException to IonElementException

### DIFF
--- a/src/com/amazon/ionelement/api/AnyElement.kt
+++ b/src/com/amazon/ionelement/api/AnyElement.kt
@@ -36,8 +36,8 @@ import java.math.BigInteger
  * Represents an Ion element whose type is not known at compile-time.
  *
  * [IonElement] is returned by all of the [IonElementLoader] functions and is the data type for children of [ListElement],
- * [SexpElement] and [StructElement]. If the type of an Ion element is known in advance, one can use the narrowed
- * [IonElement] APIs that can be asserted at runtime.
+ * [SexpElement] and [StructElement]. If the type of an Ion element is known at compile-time, the type may be easily
+ * asserted at runtime and a narrower [IonElement] interface may be obtained instead.
  *
  * Two categories of methods are present on this type:
  *
@@ -49,10 +49,10 @@ import java.math.BigInteger
  * - An expectation of the Ion type of the given element
  * - An expectation of the nullability of the given element
  *
- * If either of these expectations is violated an [IonElementException] is thrown.  If the given element
- * has a [IonLocation] in its metadata, it included with the [IonElementException] which can be used to
- * generate error an message that points to the specific location of the failure within text (i.e. line & column) or
- * binary Ion data (i.e. byte offset).
+ * If either of these expectations is violated an [IonElementConstraintException] is thrown.  If the given element
+ * has an [IonLocation] in its metadata, it is included with the [IonElementConstraintException] which can be used to
+ * generate error an message that points to the specific location of the failure within the Ion-text document
+ * (i.e. line & column) or within the Ion-binary document (i.e. byte offset).
  *
  * Value Accessor Examples:
  *
@@ -102,7 +102,8 @@ import java.math.BigInteger
  * #### Deciding which accessor function to use
  *
  * **Note:  for the sake of brevity, the following section omits the nullable narrowing functions (`as*OrNull`) and
- * nullable value accessors (`*OrNull`).  These should be used whenever an Ion-null value is allowed.
+ * nullable value accessors (`*ValueOrNull` and `*ValuesOrNull`).  These should be used whenever an Ion-null value is
+ * allowed.
  *
  * The table below shows which accessor functions can be used for each [ElementType].
  *

--- a/src/com/amazon/ionelement/api/AnyElement.kt
+++ b/src/com/amazon/ionelement/api/AnyElement.kt
@@ -36,7 +36,7 @@ import java.math.BigInteger
  * Represents an Ion element whose type is not known at compile-time.
  *
  * [IonElement] is returned by all of the [IonElementLoader] functions and is the data type for children of [ListElement],
- * [SexpElement] and [StructElement]. If the type of an Ion element is known at compile-time, the type may be easily
+ * [SexpElement] and [StructElement]. If the type of an Ion element is not known at compile-time, the type may be easily
  * asserted at runtime and a narrower [IonElement] interface may be obtained instead.
  *
  * Two categories of methods are present on this type:

--- a/src/com/amazon/ionelement/api/AnyElement.kt
+++ b/src/com/amazon/ionelement/api/AnyElement.kt
@@ -49,8 +49,8 @@ import java.math.BigInteger
  * - An expectation of the Ion type of the given element
  * - An expectation of the nullability of the given element
  *
- * If either of these expectations is violated an [IonElectrolyteException] is thrown.  If the given element
- * has a [IonLocation] in its metadata, it included with the [IonElectrolyteException] which can be used to
+ * If either of these expectations is violated an [IonElementException] is thrown.  If the given element
+ * has a [IonLocation] in its metadata, it included with the [IonElementException] which can be used to
  * generate error an message that points to the specific location of the failure within text (i.e. line & column) or
  * binary Ion data (i.e. byte offset).
  *
@@ -246,7 +246,7 @@ interface AnyElement : IonElement {
     fun asStructOrNull(): StructElement?
 
     /**
-     * If this is an Ion integer, returns its [IntegerSize] otherwise, throws [IonElectrolyteException].
+     * If this is an Ion integer, returns its [IntegerSize] otherwise, throws [IonElementException].
      *
      * TODO: replace with an enum type that does not include `INT`: https://github.com/amzn/ion-element-kotlin/issues/23
      */

--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -276,7 +276,7 @@ interface StructElement : ContainerElement {
      *
      * In the case of multiple fields with the specified name, the caller assume that one is picked at random.
      *
-     * @throws IonElectrolyteException If there are no fields with the specified [fieldName].
+     * @throws IonElementException If there are no fields with the specified [fieldName].
      */
     operator fun get(fieldName: String): AnyElement
 

--- a/src/com/amazon/ionelement/api/IonElementException.kt
+++ b/src/com/amazon/ionelement/api/IonElementException.kt
@@ -15,16 +15,25 @@
 
 package com.amazon.ionelement.api
 
-import com.amazon.ionelement.api.IonLocation
-import com.amazon.ionelement.api.locationToString
-
 /**
- * Exception for IonElectrolyte.
- *
- * Includes the [IonLocation] in the message if the [location] property if it was included at construction time.
+ * Base exception which includes the [location] in the message if the if it was included at construction time.
  */
-class IonElectrolyteException @JvmOverloads constructor(
+open class IonElementException(
     val location: IonLocation?,
     val description: String,
     cause: Throwable? = null
 ) : Error(locationToString(location) + ": $description", cause)
+
+/** Exception thrown by [IonElementLoader]. */
+class IonElementLoaderException(
+    location: IonLocation?,
+    description: String,
+    cause: Throwable? = null
+) : IonElementException(location, description, cause)
+
+/** Exception thrown by [IonElement] accessor functions to indicate a type or nullness constraint has been violated. */
+class IonElementConstraintException(
+    location: IonLocation?,
+    description: String,
+    cause: Throwable? = null
+) : IonElementException(location, description, cause)

--- a/src/com/amazon/ionelement/api/IonElementException.kt
+++ b/src/com/amazon/ionelement/api/IonElementException.kt
@@ -16,7 +16,7 @@
 package com.amazon.ionelement.api
 
 /**
- * Base exception which includes the [location] in the message if the if it was included at construction time.
+ * Base exception which includes the [location] in the message if it was included at construction time.
  */
 open class IonElementException(
     val location: IonLocation?,

--- a/src/com/amazon/ionelement/api/IonElementExtensions.kt
+++ b/src/com/amazon/ionelement/api/IonElementExtensions.kt
@@ -63,30 +63,30 @@ inline fun <reified T: IonElement> T.withoutMetas(): T =
 /**
  * Returns the string representation of the symbol in the first element of this container.
  *
- * If the first element is not a symbol or this container has no elements, throws [IonElectrolyteException],
+ * If the first element is not a symbol or this container has no elements, throws [IonElementException],
  */
 val SeqElement.tag get() = this.head.symbolValue
 
 /**
  * Returns the first element of this container.
  *
- * If this container has no elements, throws [IonElectrolyteException].
+ * If this container has no elements, throws [IonElementException].
  */
 val SeqElement.head: AnyElement
     get() =
         when (this.size) {
-            0 -> ionError(this, "Cannot get head of empty container")
+            0 -> constraintError(this, "Cannot get head of empty container")
             else -> this.values.first()
         }
 
 /**
  * Returns a sub-list containing all elements of this container except the first.
  *
- * If this container has no elements, throws [IonElectrolyteException].
+ * If this container has no elements, throws [IonElementException].
  */
 val SeqElement.tail: List<AnyElement> get()  =
     when (this.size) {
-        0 -> ionError(this, "Cannot get tail of empty container")
+        0 -> constraintError(this, "Cannot get tail of empty container")
         else -> this.values.subList(1, this.size)
     }
 

--- a/src/com/amazon/ionelement/api/IonElementLoader.kt
+++ b/src/com/amazon/ionelement/api/IonElementLoader.kt
@@ -21,7 +21,7 @@ import com.amazon.ion.IonReader
  * Provides several functions for loading [IonElement] instances.
  *
  * All functions wrap any [com.amazon.ion.IonException] in an instance of [IonElementLoaderException], including the
- * current [IonLocation] if if one is available.  Note that depending on the state of the [IonReader], a location
+ * current [IonLocation] if one is available.  Note that depending on the state of the [IonReader], a location
  * may not be available.
  */
 interface IonElementLoader {

--- a/src/com/amazon/ionelement/api/IonElementLoader.kt
+++ b/src/com/amazon/ionelement/api/IonElementLoader.kt
@@ -17,11 +17,18 @@ package com.amazon.ionelement.api
 
 import com.amazon.ion.IonReader
 
+/**
+ * Provides several functions for loading [IonElement] instances.
+ *
+ * All functions wrap any [com.amazon.ion.IonException] in an instance of [IonElementLoaderException], including the
+ * current [IonLocation] if if one is available.  Note that depending on the state of the [IonReader], a location
+ * may not be available.
+ */
 interface IonElementLoader {
     /**
      * Reads a single element from the specified Ion text data.
      *
-     * Throws an [IllegalArgumentException] if there are multiple top level elements.
+     * Throws an [IonElementLoaderException] if there are multiple top level elements.
      */
     fun loadSingleElement(ionText: String): AnyElement
 
@@ -31,7 +38,7 @@ interface IonElementLoader {
      * Expects [ionReader] to be positioned *before* the element to be read.
      *
      * If there are additional elements to be read after reading the next element,
-     * throws an [IllegalArgumentException].
+     * throws an [IonElementLoaderException].
      */
     fun loadSingleElement(ionReader: IonReader): AnyElement
 
@@ -41,7 +48,7 @@ interface IonElementLoader {
      * Expects [ionReader] to be positioned *before* the first element to be read.
      *
      * Avoid this function when reading large amounts of Ion because a large amount of memory will be consumed.
-     * Instead, prefer [loadCurrentElement].
+     * Instead, prefer [IonElementLoaderException].
      */
     fun loadAllElements(ionReader: IonReader): List<AnyElement>
 

--- a/src/com/amazon/ionelement/api/IonUtils.kt
+++ b/src/com/amazon/ionelement/api/IonUtils.kt
@@ -52,12 +52,12 @@ fun IonValue.toIonElement(): AnyElement =
         createIonElementLoader().loadSingleElement(reader)
     }
 
-/** Throws an [IonElectrolyteException], including the [IonLocation] (if available). */
-fun ionError(blame: IonElement, description: String): Nothing {
-    ionError(blame.metas, description)
+/** Throws an [IonElementException], including the [IonLocation] (if available). */
+internal fun constraintError(blame: IonElement, description: String): Nothing {
+    constraintError(blame.metas, description)
 }
 
-/** Throws an [IonElectrolyteException], including the [IonLocation] (if available). */
-fun ionError(metas: MetaContainer, description: String): Nothing {
-    throw IonElectrolyteException(metas.location, description)
+/** Throws an [IonElementException], including the [IonLocation] (if available). */
+internal fun constraintError(metas: MetaContainer, description: String): Nothing {
+    throw IonElementConstraintException(metas.location, description)
 }

--- a/src/com/amazon/ionelement/impl/AnyElementBase.kt
+++ b/src/com/amazon/ionelement/impl/AnyElementBase.kt
@@ -54,7 +54,7 @@ import com.amazon.ionelement.api.StructElement
 import com.amazon.ionelement.api.SymbolElement
 import com.amazon.ionelement.api.TextElement
 import com.amazon.ionelement.api.TimestampElement
-import com.amazon.ionelement.api.ionError
+import com.amazon.ionelement.api.constraintError
 import java.math.BigInteger
 
 private val TEXT_WRITER_BUILDER = IonTextWriterBuilder.standard()
@@ -83,7 +83,7 @@ internal abstract class AnyElementBase : AnyElement {
         TEXT_WRITER_BUILDER.build(buf).use { writeTo(it) }
     }.toString()
 
-    override val integerSize: IntegerSize get() = ionError(this, "integerSize not valid for this Element")
+    override val integerSize: IntegerSize get() = constraintError(this, "integerSize not valid for this Element")
 
     private inline fun <reified T: IonElement> requireTypeAndCastOrNull(allowedType: ElementType): T? {
         if(this.type == NULL) {
@@ -101,15 +101,15 @@ internal abstract class AnyElementBase : AnyElement {
     }
 
     private fun errIfNotTyped(allowedType: ElementType): Nothing {
-        ionError(this, "Expected an element of type $allowedType but found an element of type ${this.type}")
+        constraintError(this, "Expected an element of type $allowedType but found an element of type ${this.type}")
     }
 
     private fun errIfNotTyped(allowedType: ElementType, allowedType2: ElementType): Nothing  {
-        ionError(this, "Expected an element of type $allowedType or $allowedType2 but found an element of type ${this.type}")
+        constraintError(this, "Expected an element of type $allowedType or $allowedType2 but found an element of type ${this.type}")
     }
 
     private fun errIfNotTyped(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): Nothing  {
-        ionError(this, "Expected an element of type $allowedType, $allowedType2 or $allowedType3 but found an element of type ${this.type}")
+        constraintError(this, "Expected an element of type $allowedType, $allowedType2 or $allowedType3 but found an element of type ${this.type}")
     }
 
     private inline fun <reified T: IonElement> requireTypeAndCastOrNull(allowedType: ElementType, allowedType2: ElementType): T? {
@@ -133,7 +133,7 @@ internal abstract class AnyElementBase : AnyElement {
         }
 
         if(this.type != allowedType && this.type != allowedType2 && this.type != allowedType3)
-            ionError(this, "Expected an element of type $allowedType, $allowedType2 or $allowedType3 but found an element of type ${this.type}")
+            constraintError(this, "Expected an element of type $allowedType, $allowedType2 or $allowedType3 but found an element of type ${this.type}")
 
         return when {
             // this could still be a typed null
@@ -143,17 +143,17 @@ internal abstract class AnyElementBase : AnyElement {
     }
 
     private inline fun <reified T: IonElement> requireTypeAndCast(allowedType: ElementType): T {
-        requireTypeAndCastOrNull<T>(allowedType) ?: ionError(this, "Required non-null value of type $allowedType but found a $this")
+        requireTypeAndCastOrNull<T>(allowedType) ?: constraintError(this, "Required non-null value of type $allowedType but found a $this")
         return this as T
     }
 
     private inline fun <reified T: IonElement> requireTypeAndCast(allowedType: ElementType, allowedType2: ElementType): T {
-        requireTypeAndCastOrNull<T>(allowedType, allowedType2) ?: ionError(this, "Required non-null value of type $allowedType or $allowedType2 but found a $this")
+        requireTypeAndCastOrNull<T>(allowedType, allowedType2) ?: constraintError(this, "Required non-null value of type $allowedType or $allowedType2 but found a $this")
         return this as T
     }
 
     private inline fun <reified T: IonElement> requireTypeAndCast(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): T {
-        requireTypeAndCastOrNull<T>(allowedType, allowedType2, allowedType3) ?: ionError(this, "Required non-null value of type $allowedType, $allowedType2 or $allowedType3 but found a $this")
+        requireTypeAndCastOrNull<T>(allowedType, allowedType2, allowedType3) ?: constraintError(this, "Required non-null value of type $allowedType, $allowedType2 or $allowedType3 but found a $this")
         return this as T
     }
 

--- a/src/com/amazon/ionelement/impl/BigIntIonElement.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIonElement.kt
@@ -21,7 +21,7 @@ import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.IntElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ionelement.api.ionError
+import com.amazon.ionelement.api.constraintError
 import java.math.BigInteger
 
 internal class BigIntIonElement(
@@ -36,7 +36,7 @@ internal class BigIntIonElement(
 
     override val longValue: Long get() {
         if(bigIntegerValue > MAX_LONG_AS_BIG_INT || bigIntegerValue < MIN_LONG_AS_BIG_INT) {
-            ionError(this, "Ion integer value outside of range of 64 bit signed integer, use bigIntegerValue instead.")
+            constraintError(this, "Ion integer value outside of range of 64 bit signed integer, use bigIntegerValue instead.")
         }
         return bigIntegerValue.longValueExact()
     }

--- a/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -23,11 +23,12 @@ import com.amazon.ion.OffsetSpan
 import com.amazon.ion.SpanProvider
 import com.amazon.ion.TextSpan
 import com.amazon.ion.system.IonReaderBuilder
+import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ION_LOCATION_META_TAG
 import com.amazon.ionelement.api.IonBinaryLocation
-import com.amazon.ionelement.api.IonElectrolyteException
-import com.amazon.ionelement.api.AnyElement
+import com.amazon.ionelement.api.IonElementException
 import com.amazon.ionelement.api.IonElementLoader
+import com.amazon.ionelement.api.IonElementLoaderException
 import com.amazon.ionelement.api.IonLocation
 import com.amazon.ionelement.api.IonStructField
 import com.amazon.ionelement.api.IonTextLocation
@@ -51,11 +52,17 @@ import com.amazon.ionelement.api.withAnnotations
 import com.amazon.ionelement.api.withMetas
 
 class IonElementLoaderImpl(private val includeLocations: Boolean) : IonElementLoader {
+
+    /**
+     * Catches an [IonException] occurring in [block] and throws an [IonElementLoaderException] with
+     * the current [IonLocation] of the fault, if one is available.  Note that depending on the state of the
+     * [IonReader], a location may in fact not be available.
+     */
     private inline fun <T> handleReaderException(ionReader: IonReader, crossinline block: () -> T): T {
         try {
             return block()
         } catch(e: IonException) {
-            throw IonElectrolyteException(
+            throw IonElementException(
                 location = ionReader.currentLocation(),
                 description = "IonException occurred, likely due to malformed Ion data (see cause)",
                 cause = e)

--- a/src/com/amazon/ionelement/impl/StructIonElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructIonElementImpl.kt
@@ -23,7 +23,7 @@ import com.amazon.ionelement.api.IonStructField
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.StructElement
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ionelement.api.ionError
+import com.amazon.ionelement.api.constraintError
 
 internal class StructIonElementImpl(
     private val allFields: List<IonStructField>,
@@ -47,7 +47,7 @@ internal class StructIonElementImpl(
     }
 
     override fun get(fieldName: String): AnyElement =
-        fieldsByName[fieldName]?.firstOrNull() ?: ionError(this, "Required struct field '$fieldName' missing")
+        fieldsByName[fieldName]?.firstOrNull() ?: constraintError(this, "Required struct field '$fieldName' missing")
 
     override fun getOptional(fieldName: String): AnyElement? =
         fieldsByName[fieldName]?.firstOrNull()

--- a/test/com/amazon/ionelement/AnyElementTests.kt
+++ b/test/com/amazon/ionelement/AnyElementTests.kt
@@ -31,7 +31,7 @@ import com.amazon.ionelement.api.ElementType.STRING
 import com.amazon.ionelement.api.ElementType.STRUCT
 import com.amazon.ionelement.api.ElementType.SYMBOL
 import com.amazon.ionelement.api.ElementType.TIMESTAMP
-import com.amazon.ionelement.api.IonElectrolyteException
+import com.amazon.ionelement.api.IonElementException
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.impl.IonByteArrayImpl
 import com.amazon.ionelement.util.loadSingleElement
@@ -108,7 +108,7 @@ class AnyElementTests {
         }
 
         private fun checkThrows(block: () -> Unit) {
-            assertThrows<IonElectrolyteException> { block() }
+            assertThrows<IonElementException> { block() }
         }
 
         /** Asserts the null and non-null value accessor properties return the expected values. */

--- a/test/com/amazon/ionelement/StructIonElementTests.kt
+++ b/test/com/amazon/ionelement/StructIonElementTests.kt
@@ -15,7 +15,7 @@
 
 package com.amazon.ionelement
 
-import com.amazon.ionelement.api.IonElectrolyteException
+import com.amazon.ionelement.api.IonElementException
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.IonStructField
 import com.amazon.ionelement.api.ionInt
@@ -62,7 +62,7 @@ class StructIonElementTests {
         assertTrue(listOf(ionInt(2), ionInt(3)).any { it == b1 },
             "any value of the b field is returned (duplicate field name)")
 
-        val ex = assertThrows<IonElectrolyteException>("exception is thrown when field is not present") {
+        val ex = assertThrows<IonElementException>("exception is thrown when field is not present") {
             struct["z"]
         }
         assertTrue(ex.message!!.contains("'z'"),

--- a/test/com/amazon/ionelement/demos/UnexpectedTypesTest.kt
+++ b/test/com/amazon/ionelement/demos/UnexpectedTypesTest.kt
@@ -15,7 +15,7 @@
 
 package com.amazon.ionelement.demos
 
-import com.amazon.ionelement.api.IonElectrolyteException
+import com.amazon.ionelement.api.IonElementException
 import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.IonLocation
 import com.amazon.ionelement.api.IonTextLocation
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 /**
- * Demonstrates throwing of [IonElectrolyteException] when an unexpected data type or nulliness is encountered.
+ * Demonstrates throwing of [IonElementException] when an unexpected data type or nulliness is encountered.
  */
 class UnexpectedTypesTest {
     private val loader = createIonElementLoader(includeLocations = true)
@@ -41,7 +41,7 @@ class UnexpectedTypesTest {
     @MethodSource("parametersForIonElectrolyteExceptionTest")
     fun ionElectrolyteExceptionTest(tc: TestCase) {
         val ionElement = loader.loadSingleElement(tc.ionText)
-        val ex = assertThrows<IonElectrolyteException> { tc.block(ionElement) }
+        val ex = assertThrows<IonElementException> { tc.block(ionElement) }
         assertEquals(tc.expectedIonLocation, ex.location)
     }
 


### PR DESCRIPTION
Implements #14

- Rename IonElectrolyteException to IonElementException
- Add IonElementLoaderException and throw it from IonElementLoaderImpl
- Add IonElementConstraintException and throw it from AnyIonElement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
