### PR TITLE
Rename implementation types for consistency

### DIFF
--- a/src/com/amazon/ionelement/api/Ion.kt
+++ b/src/com/amazon/ionelement/api/Ion.kt
@@ -19,22 +19,22 @@ package com.amazon.ionelement.api
 
 import com.amazon.ion.Decimal
 import com.amazon.ion.Timestamp
-// TODO: Make make implementation names consistent.  https://github.com/amzn/ion-element-kotlin/issues/24
-import com.amazon.ionelement.impl.BigIntIonElement
-import com.amazon.ionelement.impl.BlobIonElement
-import com.amazon.ionelement.impl.BoolIonElement
-import com.amazon.ionelement.impl.ClobIonElement
-import com.amazon.ionelement.impl.DecimalIonElement
-import com.amazon.ionelement.impl.FloatIonElement
-import com.amazon.ionelement.impl.IntIonElement
+
+import com.amazon.ionelement.impl.BigIntIntElementImpl
+import com.amazon.ionelement.impl.BlobElementImpl
+import com.amazon.ionelement.impl.BoolElementImpl
+import com.amazon.ionelement.impl.ClobElementImpl
+import com.amazon.ionelement.impl.DecimalElementImpl
+import com.amazon.ionelement.impl.FloatElementImpl
+import com.amazon.ionelement.impl.LongIntElementImpl
 import com.amazon.ionelement.impl.StructFieldImpl
-import com.amazon.ionelement.impl.ListIonElementBase
-import com.amazon.ionelement.impl.NullIonElement
-import com.amazon.ionelement.impl.SexpIonElementArray
-import com.amazon.ionelement.impl.StringIonElement
-import com.amazon.ionelement.impl.StructIonElementImpl
-import com.amazon.ionelement.impl.SymbolIonElement
-import com.amazon.ionelement.impl.TimestampIonElement
+import com.amazon.ionelement.impl.ListElementImpl
+import com.amazon.ionelement.impl.NullElementImpl
+import com.amazon.ionelement.impl.SexpElementImpl
+import com.amazon.ionelement.impl.StringElementImpl
+import com.amazon.ionelement.impl.StructElementImpl
+import com.amazon.ionelement.impl.SymbolElementImpl
+import com.amazon.ionelement.impl.TimestampElementImpl
 import java.math.BigInteger
 
 // TODO:  add "metas: MetaContainer = emptyMetaContainer()" to all IonElement constructor functions.
@@ -46,38 +46,38 @@ import java.math.BigInteger
 fun ionNull(elementType: ElementType = ElementType.NULL): IonElement = ALL_NULLS.getValue(elementType)
 
 /** Creates a [StringElement] that represents an Ion `symbol`. */
-fun ionString(s: String): StringElement = StringIonElement(s)
+fun ionString(s: String): StringElement = StringElementImpl(s)
 
 /** Creates a [SymbolElement] that represents an Ion `symbol`. */
-fun ionSymbol(s: String): SymbolElement = SymbolIonElement(s)
+fun ionSymbol(s: String): SymbolElement = SymbolElementImpl(s)
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
-fun ionTimestamp(s: String): TimestampElement = TimestampIonElement(Timestamp.valueOf(s))
+fun ionTimestamp(s: String): TimestampElement = TimestampElementImpl(Timestamp.valueOf(s))
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
-fun ionTimestamp(timestamp: Timestamp): TimestampElement = TimestampIonElement(timestamp)
+fun ionTimestamp(timestamp: Timestamp): TimestampElement = TimestampElementImpl(timestamp)
 
 /** Creates an [IntElement] that represents an Ion `int`. */
-fun ionInt(l: Long): IntElement = IntIonElement(l)
+fun ionInt(l: Long): IntElement = LongIntElementImpl(l)
 
 /** Creates an [IntElement] that represents an Ion `BitInteger`. */
-fun ionInt(bigInt: BigInteger): IntElement = BigIntIonElement(bigInt)
+fun ionInt(bigInt: BigInteger): IntElement = BigIntIntElementImpl(bigInt)
 
 /** Creates a [BoolElement] that represents an Ion `bool`. */
-fun ionBool(b: Boolean): BoolElement = BoolIonElement(b)
+fun ionBool(b: Boolean): BoolElement = BoolElementImpl(b)
 
 /** Creates a [FloatElement] that represents an Ion `float`. */
-fun ionFloat(d: Double): FloatElement = FloatIonElement(d)
+fun ionFloat(d: Double): FloatElement = FloatElementImpl(d)
 
 /** Creates a [DecimalElement] that represents an Ion `decimall`. */
-fun ionDecimal(bigDecimal: Decimal): DecimalElement = DecimalIonElement(bigDecimal)
+fun ionDecimal(bigDecimal: Decimal): DecimalElement = DecimalElementImpl(bigDecimal)
 
 /**
  * Creates a [BlobElement] that represents an Ion `blob`.
  *
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
-fun ionBlob(bytes: ByteArray): BlobElement = BlobIonElement(bytes.clone())
+fun ionBlob(bytes: ByteArray): BlobElement = BlobElementImpl(bytes.clone())
 
 /** Returns the empty [BlobElement] singleton. */
 fun emptyBlob(): BlobElement = EMPTY_BLOB
@@ -87,7 +87,7 @@ fun emptyBlob(): BlobElement = EMPTY_BLOB
  *
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
-fun ionClob(bytes: ByteArray): ClobElement = ClobIonElement(bytes.clone())
+fun ionClob(bytes: ByteArray): ClobElement = ClobElementImpl(bytes.clone())
 
 /** Returns the empty [ClobElement] singleton. */
 fun emptyClob(): ClobElement = EMPTY_CLOB
@@ -96,7 +96,7 @@ fun emptyClob(): ClobElement = EMPTY_CLOB
 fun ionListOf(iterable: Iterable<IonElement>): ListElement =
     when {
         iterable.none() -> EMPTY_LIST
-        else -> ListIonElementBase(iterable.map { it.asAnyElement() })
+        else -> ListElementImpl(iterable.map { it.asAnyElement() })
     }
 
 /** Creates a [ListElement] that represents an Ion `list`. */
@@ -110,7 +110,7 @@ fun emptyIonList(): ListElement = EMPTY_LIST
 fun ionSexpOf(iterable: Iterable<IonElement>, metas: MetaContainer = emptyMetaContainer()): SexpElement =
     when {
         iterable.none() -> EMPTY_SEXP
-        else -> SexpIonElementArray(iterable.map { it.asAnyElement() }, metas = metas)
+        else -> SexpElementImpl(iterable.map { it.asAnyElement() }, metas = metas)
     }
 
 /** Creates a [SexpElement] that represents an Ion `sexp`. */
@@ -131,7 +131,7 @@ fun field(key: String, value: IonElement): StructField =
 fun ionStructOf(fields: Iterable<StructField>): StructElement =
     when {
         fields.none() -> EMPTY_STRUCT
-        else -> StructIonElementImpl(fields.toList())
+        else -> StructElementImpl(fields.toList())
     }
 
 /** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
@@ -143,11 +143,11 @@ fun ionStructOf(vararg fields: Pair<String, IonElement>): StructElement =
     ionStructOf(fields.map { field(it.first, it.second.asAnyElement()) })
 
 // Memoized empty instances of our container types.
-private val EMPTY_LIST = ListIonElementBase(emptyList())
-private val EMPTY_SEXP = SexpIonElementArray(emptyList())
-private val EMPTY_STRUCT = StructIonElementImpl(emptyList())
-private val EMPTY_BLOB = BlobIonElement(ByteArray(0))
-private val EMPTY_CLOB = ClobIonElement(ByteArray(0))
+private val EMPTY_LIST = ListElementImpl(emptyList())
+private val EMPTY_SEXP = SexpElementImpl(emptyList())
+private val EMPTY_STRUCT = StructElementImpl(emptyList())
+private val EMPTY_BLOB = BlobElementImpl(ByteArray(0))
+private val EMPTY_CLOB = ClobElementImpl(ByteArray(0))
 
 // Memoized instances of all of our null values.
-private val ALL_NULLS = ElementType.values().map { it to NullIonElement(it) as IonElement }.toMap()
+private val ALL_NULLS = ElementType.values().map { it to NullElementImpl(it) as IonElement }.toMap()

--- a/src/com/amazon/ionelement/impl/BlobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BlobElementImpl.kt
@@ -16,23 +16,24 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.ClobElement
-import com.amazon.ionelement.api.ElementType
+import com.amazon.ionelement.api.BlobElement
 import com.amazon.ionelement.api.ByteArrayView
+import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class ClobIonElement(
+internal class BlobElementImpl(
     bytes: ByteArray,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-) : BinaryIonElement(bytes), ClobElement {
+) : LobElementBase(bytes), BlobElement {
 
-    override val clobValue: ByteArrayView get() = bytesValue
+    override val blobValue: ByteArrayView get() = bytesValue
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeClob(bytes)
-    override fun copy(annotations: List<String>, metas: MetaContainer): ClobElement =
-        ClobIonElement(bytes, annotations, metas)
+    override fun writeContentTo(writer: IonWriter) = writer.writeBlob(bytes)
 
-    override val type: ElementType get() = ElementType.CLOB
+    override fun copy(annotations: List<String>, metas: MetaContainer): BlobElement =
+        BlobElementImpl(bytes, annotations, metas)
+
+    override val type: ElementType get() = ElementType.BLOB
 }

--- a/src/com/amazon/ionelement/impl/BoolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BoolElementImpl.kt
@@ -16,41 +16,40 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.BoolElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.SymbolElement
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class SymbolIonElement(
-    value: String,
+internal class BoolElementImpl(
+    override val booleanValue: Boolean,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-): TextIonElement(value), SymbolElement {
-    override val type: ElementType get() = ElementType.SYMBOL
+): AnyElementBase(), BoolElement {
+    override val type: ElementType get() = ElementType.BOOL
 
-    override val symbolValue: String get() = textValue
+    override fun copy(annotations: List<String>, metas: MetaContainer): BoolElement =
+        BoolElementImpl(booleanValue, annotations, metas)
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElement =
-        SymbolIonElement(textValue, annotations, metas)
-
-    override fun writeContentTo(writer: IonWriter) = writer.writeSymbol(textValue)
+    override fun writeContentTo(writer: IonWriter) = writer.writeBool(booleanValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as SymbolIonElement
+        other as BoolElementImpl
 
-        if (textValue != other.textValue) return false
+        if (booleanValue != other.booleanValue) return false
         if (annotations != other.annotations) return false
-        // Note: metas intentionally omittted!
+        // Note: metas intentionally omitted!
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = textValue.hashCode()
+        var result = booleanValue.hashCode()
         result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omittted!
+        // Note: metas intentionally omitted!
         return result
     }
+
 }

--- a/src/com/amazon/ionelement/impl/ByteArrayViewImpl.kt
+++ b/src/com/amazon/ionelement/impl/ByteArrayViewImpl.kt
@@ -2,7 +2,7 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ionelement.api.ByteArrayView
 
-class IonByteArrayImpl(private val bytes: ByteArray) : ByteArrayView {
+class ByteArrayViewImpl(private val bytes: ByteArray) : ByteArrayView {
     override fun size(): Int = bytes.size
 
     override fun get(index: Int): Byte = bytes[index]
@@ -13,7 +13,7 @@ class IonByteArrayImpl(private val bytes: ByteArray) : ByteArrayView {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is IonByteArrayImpl) return false
+        if (other !is ByteArrayViewImpl) return false
 
         if (!bytes.contentEquals(other.bytes)) return false
 

--- a/src/com/amazon/ionelement/impl/ClobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ClobElementImpl.kt
@@ -16,24 +16,23 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.BlobElement
-import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.ByteArrayView
+import com.amazon.ionelement.api.ClobElement
+import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class BlobIonElement(
+internal class ClobElementImpl(
     bytes: ByteArray,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-) : BinaryIonElement(bytes), BlobElement {
+) : LobElementBase(bytes), ClobElement {
 
-    override val blobValue: ByteArrayView get() = bytesValue
+    override val clobValue: ByteArrayView get() = bytesValue
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeBlob(bytes)
+    override fun writeContentTo(writer: IonWriter) = writer.writeClob(bytes)
+    override fun copy(annotations: List<String>, metas: MetaContainer): ClobElement =
+        ClobElementImpl(bytes, annotations, metas)
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): BlobElement =
-        BlobIonElement(bytes, annotations, metas)
-
-    override val type: ElementType get() = ElementType.BLOB
+    override val type: ElementType get() = ElementType.CLOB
 }

--- a/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
@@ -15,30 +15,32 @@
 
 package com.amazon.ionelement.impl
 
+import com.amazon.ion.Decimal
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.BoolElement
+import com.amazon.ionelement.api.DecimalElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class BoolIonElement(
-    override val booleanValue: Boolean,
+internal class DecimalElementImpl(
+    override val decimalValue: Decimal,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-): AnyElementBase(), BoolElement {
-    override val type: ElementType get() = ElementType.BOOL
+) : AnyElementBase(), DecimalElement {
+    override val type get() = ElementType.DECIMAL
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): BoolElement =
-        BoolIonElement(booleanValue, annotations, metas)
+    override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElement =
+        DecimalElementImpl(decimalValue, annotations, metas)
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeBool(booleanValue)
+    override fun writeContentTo(writer: IonWriter) = writer.writeDecimal(decimalValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as BoolIonElement
+        other as DecimalElementImpl
 
-        if (booleanValue != other.booleanValue) return false
+        // `==` considers `0d0` and `-0d0` to be equivalent.  `Decimal.equals` does not.
+        if (!Decimal.equals(decimalValue, other.decimalValue)) return false
         if (annotations != other.annotations) return false
         // Note: metas intentionally omitted!
 
@@ -46,10 +48,10 @@ internal class BoolIonElement(
     }
 
     override fun hashCode(): Int {
-        var result = booleanValue.hashCode()
+        var result = decimalValue.isNegativeZero.hashCode()
+        result = 31 * result + decimalValue.hashCode()
         result = 31 * result + annotations.hashCode()
         // Note: metas intentionally omitted!
         return result
     }
-
 }

--- a/src/com/amazon/ionelement/impl/FloatElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/FloatElementImpl.kt
@@ -15,41 +15,43 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ionelement.api.AnyElement
+import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.ElementType
+import com.amazon.ionelement.api.FloatElement
 import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.SexpElement
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class SexpIonElementArray (
-    values: List<AnyElement>,
+internal class FloatElementImpl(
+    override val doubleValue: Double,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-):  SeqElementBase(values), SexpElement {
-    override val type: ElementType get() = ElementType.SEXP
+) : AnyElementBase(), FloatElement {
+    override val type: ElementType get() = ElementType.FLOAT
 
-    override val sexpValues: List<AnyElement> get() = seqValues
+    override fun copy(annotations: List<String>, metas: MetaContainer): FloatElement =
+        FloatElementImpl(doubleValue, annotations, metas)
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): SexpElement =
-        SexpIonElementArray(values, annotations, metas)
-
+    override fun writeContentTo(writer: IonWriter) = writer.writeFloat(doubleValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as SexpIonElementArray
+        other as FloatElementImpl
 
-        if (values != other.values) return false
+        // compareTo() distinguishes between 0.0 and -0.0 while `==` operator does not.
+        if (doubleValue.compareTo(other.doubleValue) != 0) return false
         if (annotations != other.annotations) return false
-        // Note: [metas] intentionally omitted!
+        // Note: metas intentionally omitted!
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = values.hashCode()
+        var result = doubleValue.compareTo(0.0).hashCode() // <-- causes 0e0 to have a different hash code than -0e0
+        result = 31 * result + doubleValue.hashCode()
         result = 31 * result + annotations.hashCode()
-        // Note: [metas] intentionally omitted!
+        // Note: metas intentionally omitted!
         return result
     }
+
 }

--- a/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -31,8 +31,8 @@ import com.amazon.ionelement.api.IonElementLoader
 import com.amazon.ionelement.api.IonElementLoaderException
 import com.amazon.ionelement.api.IonElementLoaderOptions
 import com.amazon.ionelement.api.IonLocation
-import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.IonTextLocation
+import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ionelement.api.ionBlob
 import com.amazon.ionelement.api.ionBool

--- a/src/com/amazon/ionelement/impl/ListElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ListElementImpl.kt
@@ -15,42 +15,42 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
+import com.amazon.ionelement.api.ListElement
 import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.StringElement
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class StringIonElement(
-    value: String,
+internal class ListElementImpl (
+    values: List<AnyElement>,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-): TextIonElement(value), StringElement {
-    override val type: ElementType get() = ElementType.STRING
+): SeqElementBase(values), ListElement {
+    override val type: ElementType get() = ElementType.LIST
 
-    override val stringValue: String get() = textValue
+    override val listValues: List<AnyElement> get() = values
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): StringElement =
-        StringIonElement(textValue, annotations, metas)
+    override fun copy(annotations: List<String>, metas: MetaContainer): ListElement =
+        ListElementImpl(values, annotations, metas)
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeString(textValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as StringIonElement
+        other as ListElementImpl
 
-        if (textValue != other.textValue) return false
+        if (values != other.values) return false
         if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
+        // Note: [metas] intentionally omitted!
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = textValue.hashCode()
+        var result = values.hashCode()
         result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
+        // Note: [metas] intentionally omitted!
+
         return result
     }
 }

--- a/src/com/amazon/ionelement/impl/LobElementBase.kt
+++ b/src/com/amazon/ionelement/impl/LobElementBase.kt
@@ -18,16 +18,16 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.ByteArrayView
 import com.amazon.ionelement.api.LobElement
 
-internal abstract class BinaryIonElement(
+internal abstract class LobElementBase(
     protected val bytes: ByteArray
 ): AnyElementBase(), LobElement {
 
-    override val bytesValue: ByteArrayView = IonByteArrayImpl(bytes) 
+    override val bytesValue: ByteArrayView = ByteArrayViewImpl(bytes)
 
     override fun equals(other: Any?): Boolean {
         return when {
             this === other -> true
-            other !is BinaryIonElement -> false
+            other !is LobElementBase -> false
             type != other.type -> false
             !bytes.contentEquals(other.bytes) -> false
             annotations != other.annotations -> false

--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -16,32 +16,31 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ion.Timestamp
 import com.amazon.ionelement.api.ElementType
+import com.amazon.ionelement.api.IntElement
+import com.amazon.ionelement.api.IntElementSize
 import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.TimestampElement
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class TimestampIonElement(
-    val value: Timestamp,
+internal class LongIntElementImpl(
+    override val longValue: Long,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-): AnyElementBase(), TimestampElement {
-    constructor(timestamp: String): this(Timestamp.valueOf(timestamp))
+) : AnyElementBase(), IntElement {
+    override val integerSize: IntElementSize get() = IntElementSize.LONG
+    override val type: ElementType get() = ElementType.INT
 
-    override val type: ElementType get() = ElementType.TIMESTAMP
-    override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElement =
-        TimestampIonElement(value, annotations, metas)
+    override fun copy(annotations: List<String>, metas: MetaContainer): IntElement =
+        LongIntElementImpl(longValue, annotations, metas)
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeTimestamp(value)
-
+    override fun writeContentTo(writer: IonWriter) = writer.writeInt(longValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as TimestampIonElement
+        other as LongIntElementImpl
 
-        if (value != other.value) return false
+        if (longValue != other.longValue) return false
         if (annotations != other.annotations) return false
         // Note: metas intentionally omitted!
 
@@ -49,9 +48,10 @@ internal class TimestampIonElement(
     }
 
     override fun hashCode(): Int {
-        var result = value.hashCode()
+        var result = longValue.hashCode()
         result = 31 * result + annotations.hashCode()
         // Note: metas intentionally omitted!
         return result
     }
 }
+

--- a/src/com/amazon/ionelement/impl/NullElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/NullElementImpl.kt
@@ -15,45 +15,32 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ion.IntegerSize
 import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.IntElement
-import com.amazon.ionelement.api.IntElementSize
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ionelement.api.constraintError
-import java.math.BigInteger
 
-internal class BigIntIonElement(
-    override val bigIntegerValue: BigInteger,
+internal class NullElementImpl(
+    override val type: ElementType = ElementType.NULL,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-) : AnyElementBase(), IntElement {
+): AnyElementBase() {
 
-    override val type: ElementType get() = ElementType.INT
+    override val isNull: Boolean get() = true
 
-    override val integerSize: IntElementSize get() = IntElementSize.BIG_INTEGER
+    override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement =
+        NullElementImpl(type, annotations, metas)
 
-    override val longValue: Long get() {
-        if(bigIntegerValue > MAX_LONG_AS_BIG_INT || bigIntegerValue < MIN_LONG_AS_BIG_INT) {
-            constraintError(this, "Ion integer value outside of range of 64 bit signed integer, use bigIntegerValue instead.")
-        }
-        return bigIntegerValue.longValueExact()
-    }
-
-    override fun copy(annotations: List<String>, metas: MetaContainer): IntElement =
-        BigIntIonElement(bigIntegerValue, annotations, metas)
-
-    override fun writeContentTo(writer: IonWriter) = writer.writeInt(bigIntegerValue)
+    override fun writeContentTo(writer: IonWriter) = writer.writeNull(type.toIonType())
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as BigIntIonElement
+        other as NullElementImpl
 
-        if (bigIntegerValue != other.bigIntegerValue) return false
+        if (type != other.type) return false
         if (annotations != other.annotations) return false
         // Note: metas intentionally omitted!
 
@@ -61,13 +48,9 @@ internal class BigIntIonElement(
     }
 
     override fun hashCode(): Int {
-        var result = bigIntegerValue.hashCode()
+        var result = type.hashCode()
         result = 31 * result + annotations.hashCode()
         // Note: metas intentionally omitted!
         return result
     }
 }
-
-internal val MAX_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MAX_VALUE)
-internal val MIN_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MIN_VALUE)
-

--- a/src/com/amazon/ionelement/impl/SexpElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SexpElementImpl.kt
@@ -15,43 +15,41 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ion.IonWriter
+import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.IntElement
-import com.amazon.ionelement.api.IntElementSize
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.SexpElement
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class IntIonElement(
-    override val longValue: Long,
+internal class SexpElementImpl (
+    values: List<AnyElement>,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-) : AnyElementBase(), IntElement {
-    override val integerSize: IntElementSize get() = IntElementSize.LONG
-    override val type: ElementType get() = ElementType.INT
+):  SeqElementBase(values), SexpElement {
+    override val type: ElementType get() = ElementType.SEXP
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): IntElement =
-        IntIonElement(longValue, annotations, metas)
+    override val sexpValues: List<AnyElement> get() = seqValues
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeInt(longValue)
+    override fun copy(annotations: List<String>, metas: MetaContainer): SexpElement =
+        SexpElementImpl(values, annotations, metas)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as IntIonElement
+        other as SexpElementImpl
 
-        if (longValue != other.longValue) return false
+        if (values != other.values) return false
         if (annotations != other.annotations) return false
-        // Note: metas intentionally omitted!
+        // Note: [metas] intentionally omitted!
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = longValue.hashCode()
+        var result = values.hashCode()
         result = 31 * result + annotations.hashCode()
-        // Note: metas intentionally omitted!
+        // Note: [metas] intentionally omitted!
         return result
     }
 }
-

--- a/src/com/amazon/ionelement/impl/StringElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StringElementImpl.kt
@@ -17,30 +17,30 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.StringElement
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class NullIonElement(
-    override val type: ElementType = ElementType.NULL,
+internal class StringElementImpl(
+    value: String,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-): AnyElementBase() {
+): TextElementBase(value), StringElement {
+    override val type: ElementType get() = ElementType.STRING
 
-    override val isNull: Boolean get() = true
+    override val stringValue: String get() = textValue
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement =
-        NullIonElement(type, annotations, metas)
+    override fun copy(annotations: List<String>, metas: MetaContainer): StringElement =
+        StringElementImpl(textValue, annotations, metas)
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeNull(type.toIonType())
-
+    override fun writeContentTo(writer: IonWriter) = writer.writeString(textValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as NullIonElement
+        other as StringElementImpl
 
-        if (type != other.type) return false
+        if (textValue != other.textValue) return false
         if (annotations != other.annotations) return false
         // Note: metas intentionally omitted!
 
@@ -48,7 +48,7 @@ internal class NullIonElement(
     }
 
     override fun hashCode(): Int {
-        var result = type.hashCode()
+        var result = textValue.hashCode()
         result = 31 * result + annotations.hashCode()
         // Note: metas intentionally omitted!
         return result

--- a/src/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -19,13 +19,13 @@ import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.StructElement
-import com.amazon.ionelement.api.emptyMetaContainer
+import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.constraintError
+import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class StructIonElementImpl(
+internal class StructElementImpl(
     private val allFields: List<StructField>,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
@@ -55,7 +55,7 @@ internal class StructIonElementImpl(
     override fun getAll(fieldName: String): Iterable<AnyElement> = fieldsByName[fieldName] ?: emptyList()
 
     override fun copy(annotations: List<String>, metas: MetaContainer): StructElement =
-        StructIonElementImpl(allFields, annotations, metas)
+        StructElementImpl(allFields, annotations, metas)
 
     override fun writeContentTo(writer: IonWriter) {
         writer.stepIn(IonType.STRUCT)
@@ -68,7 +68,7 @@ internal class StructIonElementImpl(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is StructIonElementImpl) return false
+        if (other !is StructElementImpl) return false
         if (annotations != other.annotations) return false
 
         // We might avoid materializing fieldsByName by checking fields.size first

--- a/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
@@ -15,42 +15,42 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ionelement.api.AnyElement
+import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.ListElement
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.SymbolElement
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class ListIonElementBase (
-    values: List<AnyElement>,
+internal class SymbolElementImpl(
+    value: String,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-): SeqElementBase(values), ListElement {
-    override val type: ElementType get() = ElementType.LIST
+): TextElementBase(value), SymbolElement {
+    override val type: ElementType get() = ElementType.SYMBOL
 
-    override val listValues: List<AnyElement> get() = values
+    override val symbolValue: String get() = textValue
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): ListElement =
-        ListIonElementBase(values, annotations, metas)
+    override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElement =
+        SymbolElementImpl(textValue, annotations, metas)
 
+    override fun writeContentTo(writer: IonWriter) = writer.writeSymbol(textValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as ListIonElementBase
+        other as SymbolElementImpl
 
-        if (values != other.values) return false
+        if (textValue != other.textValue) return false
         if (annotations != other.annotations) return false
-        // Note: [metas] intentionally omitted!
+        // Note: metas intentionally omittted!
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = values.hashCode()
+        var result = textValue.hashCode()
         result = 31 * result + annotations.hashCode()
-        // Note: [metas] intentionally omitted!
-
+        // Note: metas intentionally omittted!
         return result
     }
 }

--- a/src/com/amazon/ionelement/impl/TextElementBase.kt
+++ b/src/com/amazon/ionelement/impl/TextElementBase.kt
@@ -18,7 +18,7 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal abstract class TextIonElement(
+internal abstract class TextElementBase(
     override val textValue: String,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()

--- a/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
@@ -16,30 +16,32 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
+import com.amazon.ion.Timestamp
 import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.FloatElement
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.TimestampElement
 import com.amazon.ionelement.api.emptyMetaContainer
 
-internal class FloatIonElement(
-    override val doubleValue: Double,
+internal class TimestampElementImpl(
+    val value: Timestamp,
     override val annotations: List<String> = emptyList(),
     override val metas: MetaContainer = emptyMetaContainer()
-) : AnyElementBase(), FloatElement {
-    override val type: ElementType get() = ElementType.FLOAT
+): AnyElementBase(), TimestampElement {
+    constructor(timestamp: String): this(Timestamp.valueOf(timestamp))
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): FloatElement =
-        FloatIonElement(doubleValue, annotations, metas)
+    override val type: ElementType get() = ElementType.TIMESTAMP
+    override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElement =
+        TimestampElementImpl(value, annotations, metas)
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeFloat(doubleValue)
+    override fun writeContentTo(writer: IonWriter) = writer.writeTimestamp(value)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as FloatIonElement
+        other as TimestampElementImpl
 
-        // compareTo() distinguishes between 0.0 and -0.0 while `==` operator does not.
-        if (doubleValue.compareTo(other.doubleValue) != 0) return false
+        if (value != other.value) return false
         if (annotations != other.annotations) return false
         // Note: metas intentionally omitted!
 
@@ -47,11 +49,9 @@ internal class FloatIonElement(
     }
 
     override fun hashCode(): Int {
-        var result = doubleValue.compareTo(0.0).hashCode() // <-- causes 0e0 to have a different hash code than -0e0
-        result = 31 * result + doubleValue.hashCode()
+        var result = value.hashCode()
         result = 31 * result + annotations.hashCode()
         // Note: metas intentionally omitted!
         return result
     }
-
 }

--- a/test/com/amazon/ionelement/AnyElementTests.kt
+++ b/test/com/amazon/ionelement/AnyElementTests.kt
@@ -34,7 +34,7 @@ import com.amazon.ionelement.api.ElementType.TIMESTAMP
 import com.amazon.ionelement.api.IonElementException
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.loadSingleElement
-import com.amazon.ionelement.impl.IonByteArrayImpl
+import com.amazon.ionelement.impl.ByteArrayViewImpl
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -89,8 +89,8 @@ class AnyElementTests {
             TestCase("\"a string\"", STRING, "a string"),
             TestCase("a_symbol", SYMBOL, "a_symbol"),
 
-            TestCase("{{ YSBibG9i }}", BLOB, IonByteArrayImpl(Charsets.UTF_8.encode("a blob").array())),
-            TestCase("{{ \"a clob\" }}", CLOB, IonByteArrayImpl(Charsets.UTF_8.encode("a clob").array())),
+            TestCase("{{ YSBibG9i }}", BLOB, ByteArrayViewImpl(Charsets.UTF_8.encode("a blob").array())),
+            TestCase("{{ \"a clob\" }}", CLOB, ByteArrayViewImpl(Charsets.UTF_8.encode("a clob").array())),
 
             // Containers
             TestCase("[1]", LIST, listOf(ionInt(1))),


### PR DESCRIPTION
Implements #24

This is a "mechanical" rename consisting of most of the `IonElement` implementation types.  Previously, it was kind of a mess. I didn't do this until now in order to keep other PRs small.

| Old Name             | New Name                |
|----------------------|-------------------------|
|                      |                         |
| NullIonElement       | NullElementImpl         |
| BoolIonElement       | BoolElementImpl         |
| DecimalIonElement    | DecimalElementImpl      |
| FloatIonElement      | FloatElementImpl        |
| TimestampIonElement  | TimestampElementImpl    |
|                      |                         |
| TextIonElement       | TextElementBase         |
| SymbolIonElement     | SymbolElementImpl       |
| StringIonElement     | StringElementImpl       |
|                      |                         |
| IntIonElement        | LongIntElementImpl      |
| BigIntIonElement     | BigIntIntElementImpl |
|                      |                         |
| BinaryIonElement     | LobElementBase          |
| BlobIonElement       | BlobElementImpl      |
| ClobIonElement       | ClobElementImpl      |
|                      |                         |
| SeqElementBase       | [no change]             |
| ListIonElementBase   | ListElementImpl         |
| SexpIonElementArray  | SexpElementImpl         |
|                      |                         |
| StructIonElementImpl | StructElementImpl       |
| StructFieldImpl      | StructFieldImpl         |