### PR TITLE
Add annotations and metas parameter to all constructor functions

### DIFF
--- a/src/com/amazon/ionelement/api/Ion.kt
+++ b/src/com/amazon/ionelement/api/Ion.kt
@@ -19,65 +19,113 @@ package com.amazon.ionelement.api
 
 import com.amazon.ion.Decimal
 import com.amazon.ion.Timestamp
-
 import com.amazon.ionelement.impl.BigIntIntElementImpl
 import com.amazon.ionelement.impl.BlobElementImpl
 import com.amazon.ionelement.impl.BoolElementImpl
 import com.amazon.ionelement.impl.ClobElementImpl
 import com.amazon.ionelement.impl.DecimalElementImpl
 import com.amazon.ionelement.impl.FloatElementImpl
-import com.amazon.ionelement.impl.LongIntElementImpl
-import com.amazon.ionelement.impl.StructFieldImpl
 import com.amazon.ionelement.impl.ListElementImpl
+import com.amazon.ionelement.impl.LongIntElementImpl
 import com.amazon.ionelement.impl.NullElementImpl
 import com.amazon.ionelement.impl.SexpElementImpl
 import com.amazon.ionelement.impl.StringElementImpl
 import com.amazon.ionelement.impl.StructElementImpl
+import com.amazon.ionelement.impl.StructFieldImpl
 import com.amazon.ionelement.impl.SymbolElementImpl
 import com.amazon.ionelement.impl.TimestampElementImpl
 import java.math.BigInteger
 
-// TODO:  add "metas: MetaContainer = emptyMetaContainer()" to all IonElement constructor functions.
-// Currently, this is only present on [ionSexpOf] overloads.
-// https://github.com/amzn/ion-element-kotlin/issues/6
+/** Returns a memoized instance of [IonElement] that represents an Ion `null.null` or a typed `null`. */
+fun ionNull(
+    elementType: ElementType = ElementType.NULL
+): IonElement =
+    ALL_NULLS.getValue(elementType)
 
-/** Creates an [IonElement] that represents an Ion `null.null` or a typed `null`. */
-@JvmOverloads
-fun ionNull(elementType: ElementType = ElementType.NULL): IonElement = ALL_NULLS.getValue(elementType)
+/**
+ * Creates an [IonElement] that represents an Ion `null.null` or a typed `null` with the specified metas
+ * and annotations. */
+fun ionNull(
+    elementType: ElementType = ElementType.NULL,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): IonElement =
+    NullElementImpl(elementType, annotations, metas)
 
 /** Creates a [StringElement] that represents an Ion `symbol`. */
-fun ionString(s: String): StringElement = StringElementImpl(s)
+fun ionString(
+    s: String,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): StringElement = StringElementImpl(s, annotations, metas)
 
 /** Creates a [SymbolElement] that represents an Ion `symbol`. */
-fun ionSymbol(s: String): SymbolElement = SymbolElementImpl(s)
+fun ionSymbol(
+    s: String,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): SymbolElement = SymbolElementImpl(s, annotations, metas)
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
-fun ionTimestamp(s: String): TimestampElement = TimestampElementImpl(Timestamp.valueOf(s))
+fun ionTimestamp(
+    s: String,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): TimestampElement = TimestampElementImpl(Timestamp.valueOf(s), annotations, metas)
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
-fun ionTimestamp(timestamp: Timestamp): TimestampElement = TimestampElementImpl(timestamp)
+fun ionTimestamp(
+    timestamp: Timestamp,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): TimestampElement = TimestampElementImpl(timestamp, annotations, metas)
 
 /** Creates an [IntElement] that represents an Ion `int`. */
-fun ionInt(l: Long): IntElement = LongIntElementImpl(l)
+fun ionInt(
+    l: Long,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): IntElement =
+    LongIntElementImpl(l, annotations, metas)
 
 /** Creates an [IntElement] that represents an Ion `BitInteger`. */
-fun ionInt(bigInt: BigInteger): IntElement = BigIntIntElementImpl(bigInt)
+fun ionInt(
+    bigInt: BigInteger,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): IntElement = BigIntIntElementImpl(bigInt, annotations, metas)
 
 /** Creates a [BoolElement] that represents an Ion `bool`. */
-fun ionBool(b: Boolean): BoolElement = BoolElementImpl(b)
+fun ionBool(
+    b: Boolean,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): BoolElement = BoolElementImpl(b, annotations, metas)
 
 /** Creates a [FloatElement] that represents an Ion `float`. */
-fun ionFloat(d: Double): FloatElement = FloatElementImpl(d)
+fun ionFloat(
+    d: Double,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): FloatElement = FloatElementImpl(d, annotations, metas)
 
 /** Creates a [DecimalElement] that represents an Ion `decimall`. */
-fun ionDecimal(bigDecimal: Decimal): DecimalElement = DecimalElementImpl(bigDecimal)
+fun ionDecimal(
+    bigDecimal: Decimal,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): DecimalElement = DecimalElementImpl(bigDecimal, annotations, metas)
 
 /**
  * Creates a [BlobElement] that represents an Ion `blob`.
  *
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
-fun ionBlob(bytes: ByteArray): BlobElement = BlobElementImpl(bytes.clone())
+fun ionBlob(
+    bytes: ByteArray,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): BlobElement = BlobElementImpl(bytes.clone(), annotations, metas)
 
 /** Returns the empty [BlobElement] singleton. */
 fun emptyBlob(): BlobElement = EMPTY_BLOB
@@ -87,35 +135,49 @@ fun emptyBlob(): BlobElement = EMPTY_BLOB
  *
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
-fun ionClob(bytes: ByteArray): ClobElement = ClobElementImpl(bytes.clone())
+fun ionClob(
+    bytes: ByteArray,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): ClobElement = ClobElementImpl(bytes.clone(), annotations, metas)
 
 /** Returns the empty [ClobElement] singleton. */
 fun emptyClob(): ClobElement = EMPTY_CLOB
 
 /** Creates a [ListElement] that represents an Ion `list`. */
-fun ionListOf(iterable: Iterable<IonElement>): ListElement =
-    when {
-        iterable.none() -> EMPTY_LIST
-        else -> ListElementImpl(iterable.map { it.asAnyElement() })
-    }
+fun ionListOf(
+    iterable: Iterable<IonElement>,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): ListElement =
+    ListElementImpl(iterable.map { it.asAnyElement() }, annotations, metas)
 
 /** Creates a [ListElement] that represents an Ion `list`. */
-fun ionListOf(vararg elements: IonElement): ListElement =
-    ionListOf(elements.asIterable())
+fun ionListOf(
+    vararg elements: IonElement,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): ListElement =
+    ionListOf(elements.asIterable(), annotations, metas)
 
 /** Returns a [ListElement] representing an empty Ion `list`. */
 fun emptyIonList(): ListElement = EMPTY_LIST
 
 /** Creates an [SexpElement] that represents an Ion `sexp`. */
-fun ionSexpOf(iterable: Iterable<IonElement>, metas: MetaContainer = emptyMetaContainer()): SexpElement =
-    when {
-        iterable.none() -> EMPTY_SEXP
-        else -> SexpElementImpl(iterable.map { it.asAnyElement() }, metas = metas)
-    }
+fun ionSexpOf(
+    iterable: Iterable<IonElement>,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): SexpElement =
+    SexpElementImpl(iterable.map { it.asAnyElement() }, annotations, metas)
 
 /** Creates a [SexpElement] that represents an Ion `sexp`. */
-fun ionSexpOf(vararg elements: IonElement, metas: MetaContainer = emptyMetaContainer()): SexpElement =
-    ionSexpOf(elements.asIterable(), metas)
+fun ionSexpOf(
+    vararg elements: IonElement,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): SexpElement =
+    ionSexpOf(elements.asIterable(), annotations, metas)
 
 /** Returns a [SexpElement] representing an empty Ion `sexp`. */
 fun emptyIonSexp(): SexpElement = EMPTY_SEXP
@@ -128,26 +190,37 @@ fun field(key: String, value: IonElement): StructField =
     StructFieldImpl(key, value.asAnyElement())
 
 /** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
-fun ionStructOf(fields: Iterable<StructField>): StructElement =
-    when {
-        fields.none() -> EMPTY_STRUCT
-        else -> StructElementImpl(fields.toList())
-    }
+fun ionStructOf(
+    fields: Iterable<StructField>,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): StructElement =
+    StructElementImpl(fields.toList(), annotations, metas)
 
 /** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
-fun ionStructOf(vararg fields: StructField): StructElement =
-    ionStructOf(fields.asIterable())
+fun ionStructOf(
+    vararg fields: StructField,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): StructElement =
+    ionStructOf(fields.asIterable(), annotations, metas)
 
 /** Creates an [AnyElement] that represents an Ion `struct` with the specified fields. */
-fun ionStructOf(vararg fields: Pair<String, IonElement>): StructElement =
-    ionStructOf(fields.map { field(it.first, it.second.asAnyElement()) })
+fun ionStructOf(
+    vararg fields: Pair<String, IonElement>,
+    annotations: List<String> = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): StructElement =
+    ionStructOf(fields.map { field(it.first, it.second.asAnyElement()) }, annotations, metas)
 
 // Memoized empty instances of our container types.
-private val EMPTY_LIST = ListElementImpl(emptyList())
-private val EMPTY_SEXP = SexpElementImpl(emptyList())
-private val EMPTY_STRUCT = StructElementImpl(emptyList())
-private val EMPTY_BLOB = BlobElementImpl(ByteArray(0))
-private val EMPTY_CLOB = ClobElementImpl(ByteArray(0))
+private val EMPTY_LIST = ListElementImpl(emptyList(), emptyList(), emptyMetaContainer())
+private val EMPTY_SEXP = SexpElementImpl(emptyList(), emptyList(), emptyMetaContainer())
+private val EMPTY_STRUCT = StructElementImpl(emptyList(), emptyList(), emptyMetaContainer())
+private val EMPTY_BLOB = BlobElementImpl(ByteArray(0), emptyList(), emptyMetaContainer())
+private val EMPTY_CLOB = ClobElementImpl(ByteArray(0), emptyList(), emptyMetaContainer())
 
 // Memoized instances of all of our null values.
-private val ALL_NULLS = ElementType.values().map { it to NullElementImpl(it) as IonElement }.toMap()
+private val ALL_NULLS = ElementType.values().map {
+    it to NullElementImpl(it, emptyList(), emptyMetaContainer()) as IonElement
+}.toMap()

--- a/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
@@ -27,8 +27,8 @@ import java.math.BigInteger
 
 internal class BigIntIntElementImpl(
     override val bigIntegerValue: BigInteger,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ) : AnyElementBase(), IntElement {
 
     override val type: ElementType get() = ElementType.INT

--- a/src/com/amazon/ionelement/impl/BlobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BlobElementImpl.kt
@@ -20,12 +20,11 @@ import com.amazon.ionelement.api.BlobElement
 import com.amazon.ionelement.api.ByteArrayView
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class BlobElementImpl(
     bytes: ByteArray,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ) : LobElementBase(bytes), BlobElement {
 
     override val blobValue: ByteArrayView get() = bytesValue

--- a/src/com/amazon/ionelement/impl/BoolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BoolElementImpl.kt
@@ -23,8 +23,8 @@ import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class BoolElementImpl(
     override val booleanValue: Boolean,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ): AnyElementBase(), BoolElement {
     override val type: ElementType get() = ElementType.BOOL
 

--- a/src/com/amazon/ionelement/impl/ClobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ClobElementImpl.kt
@@ -24,8 +24,8 @@ import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class ClobElementImpl(
     bytes: ByteArray,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ) : LobElementBase(bytes), ClobElement {
 
     override val clobValue: ByteArrayView get() = bytesValue

--- a/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
@@ -24,8 +24,8 @@ import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class DecimalElementImpl(
     override val decimalValue: Decimal,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ) : AnyElementBase(), DecimalElement {
     override val type get() = ElementType.DECIMAL
 

--- a/src/com/amazon/ionelement/impl/FloatElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/FloatElementImpl.kt
@@ -23,8 +23,8 @@ import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class FloatElementImpl(
     override val doubleValue: Double,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ) : AnyElementBase(), FloatElement {
     override val type: ElementType get() = ElementType.FLOAT
 

--- a/src/com/amazon/ionelement/impl/ListElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ListElementImpl.kt
@@ -19,12 +19,11 @@ import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.ListElement
 import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class ListElementImpl (
     values: List<AnyElement>,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ): SeqElementBase(values), ListElement {
     override val type: ElementType get() = ElementType.LIST
 

--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -24,8 +24,8 @@ import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class LongIntElementImpl(
     override val longValue: Long,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ) : AnyElementBase(), IntElement {
     override val integerSize: IntElementSize get() = IntElementSize.LONG
     override val type: ElementType get() = ElementType.INT

--- a/src/com/amazon/ionelement/impl/NullElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/NullElementImpl.kt
@@ -23,8 +23,8 @@ import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class NullElementImpl(
     override val type: ElementType = ElementType.NULL,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ): AnyElementBase() {
 
     override val isNull: Boolean get() = true

--- a/src/com/amazon/ionelement/impl/SeqElementBase.kt
+++ b/src/com/amazon/ionelement/impl/SeqElementBase.kt
@@ -17,14 +17,10 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.SeqElement
-import com.amazon.ionelement.api.emptyMetaContainer
 
 internal abstract class SeqElementBase(
-    override val values: List<AnyElement>,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val values: List<AnyElement>
 ): AnyElementBase(), SeqElement {
 
     override val containerValues: List<AnyElement> get() = values

--- a/src/com/amazon/ionelement/impl/SexpElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SexpElementImpl.kt
@@ -19,12 +19,11 @@ import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.SexpElement
-import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class SexpElementImpl (
     values: List<AnyElement>,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ):  SeqElementBase(values), SexpElement {
     override val type: ElementType get() = ElementType.SEXP
 

--- a/src/com/amazon/ionelement/impl/StringElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StringElementImpl.kt
@@ -19,12 +19,11 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.StringElement
-import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class StringElementImpl(
     value: String,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ): TextElementBase(value), StringElement {
     override val type: ElementType get() = ElementType.STRING
 

--- a/src/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -27,8 +27,8 @@ import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class StructElementImpl(
     private val allFields: List<StructField>,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ): AnyElementBase(), StructElement {
 
     override val type: ElementType get() = ElementType.STRUCT

--- a/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
@@ -23,8 +23,8 @@ import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class SymbolElementImpl(
     value: String,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ): TextElementBase(value), SymbolElement {
     override val type: ElementType get() = ElementType.SYMBOL
 

--- a/src/com/amazon/ionelement/impl/TextElementBase.kt
+++ b/src/com/amazon/ionelement/impl/TextElementBase.kt
@@ -15,12 +15,7 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
-
 internal abstract class TextElementBase(
-    override val textValue: String,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val textValue: String
 ): AnyElementBase()
 

--- a/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
@@ -20,20 +20,18 @@ import com.amazon.ion.Timestamp
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.TimestampElement
-import com.amazon.ionelement.api.emptyMetaContainer
 
 internal class TimestampElementImpl(
-    val value: Timestamp,
-    override val annotations: List<String> = emptyList(),
-    override val metas: MetaContainer = emptyMetaContainer()
+    override val timestampValue: Timestamp,
+    override val annotations: List<String>,
+    override val metas: MetaContainer
 ): AnyElementBase(), TimestampElement {
-    constructor(timestamp: String): this(Timestamp.valueOf(timestamp))
 
     override val type: ElementType get() = ElementType.TIMESTAMP
     override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElement =
-        TimestampElementImpl(value, annotations, metas)
+        TimestampElementImpl(timestampValue, annotations, metas)
 
-    override fun writeContentTo(writer: IonWriter) = writer.writeTimestamp(value)
+    override fun writeContentTo(writer: IonWriter) = writer.writeTimestamp(timestampValue)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -41,7 +39,7 @@ internal class TimestampElementImpl(
 
         other as TimestampElementImpl
 
-        if (value != other.value) return false
+        if (timestampValue != other.timestampValue) return false
         if (annotations != other.annotations) return false
         // Note: metas intentionally omitted!
 
@@ -49,7 +47,7 @@ internal class TimestampElementImpl(
     }
 
     override fun hashCode(): Int {
-        var result = value.hashCode()
+        var result = timestampValue.hashCode()
         result = 31 * result + annotations.hashCode()
         // Note: metas intentionally omitted!
         return result

--- a/test/com/amazon/ionelement/ConstructorTests.kt
+++ b/test/com/amazon/ionelement/ConstructorTests.kt
@@ -1,0 +1,131 @@
+package com.amazon.ionelement
+
+import com.amazon.ion.Decimal
+import com.amazon.ion.Timestamp
+import com.amazon.ionelement.api.ElementType
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.SeqElement
+import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.field
+import com.amazon.ionelement.api.ionBlob
+import com.amazon.ionelement.api.ionBool
+import com.amazon.ionelement.api.ionClob
+import com.amazon.ionelement.api.ionDecimal
+import com.amazon.ionelement.api.ionFloat
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionListOf
+import com.amazon.ionelement.api.ionNull
+import com.amazon.ionelement.api.ionSexpOf
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionStructOf
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionelement.api.ionTimestamp
+import com.amazon.ionelement.api.metaContainerOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConstructorTests {
+
+    companion object {
+        val dummyMetas = metaContainerOf("foo_meta" to 1)
+        val dummyAnnotations = listOf("some_annotation")
+
+        @JvmStatic
+        @Suppress("unused")
+        fun parametersForMetasAndAnnotationsTest() = listOf(
+            ionNull(ElementType.NULL, dummyAnnotations, dummyMetas),
+            ionBool(true, dummyAnnotations, dummyMetas),
+            ionInt(123L, dummyAnnotations, dummyMetas),
+            ionInt(BigInteger.ONE, dummyAnnotations, dummyMetas),
+            ionTimestamp("2001T", dummyAnnotations, dummyMetas),
+            ionTimestamp(Timestamp.valueOf("2001T"), dummyAnnotations, dummyMetas),
+            ionFloat(1.0, dummyAnnotations, dummyMetas),
+            ionDecimal(Decimal.ZERO, dummyAnnotations, dummyMetas),
+            ionString("foo", dummyAnnotations, dummyMetas),
+            ionSymbol("foo", dummyAnnotations, dummyMetas),
+            ionClob(ByteArray(1), dummyAnnotations, dummyMetas),
+            ionBlob(ByteArray(1), dummyAnnotations, dummyMetas),
+            ionListOf(ionInt(1), annotations =  dummyAnnotations, metas = dummyMetas),
+            ionListOf(listOf(ionInt(1)), dummyAnnotations, dummyMetas),
+            ionSexpOf(ionInt(1), annotations = dummyAnnotations, metas = dummyMetas),
+            ionSexpOf(listOf(ionInt(1)), dummyAnnotations, dummyMetas),
+            ionStructOf("foo" to ionInt(1), annotations = dummyAnnotations, metas = dummyMetas),
+            ionStructOf(field("foo", ionInt(1)), annotations = dummyAnnotations, metas = dummyMetas),
+            ionStructOf(listOf(field("foo", ionInt(1))), annotations = dummyAnnotations, metas = dummyMetas)
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForMetasAndAnnotationsTest")
+    fun metasAndAnnotationsTest(elem: IonElement) {
+        assertEquals(1, elem.annotations.size)
+        assertTrue(elem.annotations.contains("some_annotation"))
+
+        assertEquals(1, elem.metas.size)
+        assertEquals(1, elem.metas["foo_meta"])
+    }
+    
+    @Test
+    fun scalarConstructorsValueTest() {
+        assertTrue(ionNull(ElementType.NULL).isNull)
+        assertEquals(true, ionBool(true).booleanValue)
+        assertEquals(false, ionBool(false).booleanValue)
+        assertEquals(123L, ionInt(123L).longValue)
+        assertEquals(BigInteger.ONE, ionInt(BigInteger.ONE).bigIntegerValue)
+        assertEquals(Timestamp.valueOf("2001T"), ionTimestamp("2001T").timestampValue)
+        assertEquals(Timestamp.valueOf("2001T"), ionTimestamp(Timestamp.valueOf("2001T")).timestampValue)
+        assertEquals(12.0, ionFloat(12.0).doubleValue)
+        assertEquals(Decimal.ZERO, ionDecimal(Decimal.ZERO).decimalValue)
+        assertEquals("foo", ionString("foo").textValue)
+        assertEquals("foo", ionSymbol("foo").textValue)
+        assertContentEquals(createBytes(), ionClob(createBytes()).bytesValue.copyOfBytes())
+        assertContentEquals(createBytes(), ionBlob(createBytes()).bytesValue.copyOfBytes())
+    }
+
+    private fun assertContentEquals(expected: ByteArray, actual: ByteArray) {
+        assertEquals(expected.size, actual.size)
+        expected.zip(actual).forEachIndexed { i, (l, r) ->
+            assertEquals(l, r, "Byte at index $i must match")
+        }
+    }
+
+    private fun createBytes() = ByteArray(3).also {
+        it[0] = 1
+        it[1] = 2
+        it[2] = 3
+    }
+
+    @Test
+    fun listConstructorsValueTest() {
+        assertSeqContents(ionListOf(ionInt(12)))
+        assertSeqContents(ionListOf(listOf(ionInt(12))))
+    }
+
+    @Test
+    fun sexpConstructorsValueTest() {
+        assertSeqContents(ionSexpOf(ionInt(12)))
+        assertSeqContents(ionSexpOf(listOf(ionInt(12))))
+    }
+
+    private fun assertSeqContents(seq: SeqElement) {
+        assertEquals(1, seq.values.size)
+        assertEquals(12, seq.values[0].longValue)
+    }
+
+    @Test
+    fun structConstructorsValueTest() {
+        assertStructContents(ionStructOf("foo" to ionInt(12)))
+        assertStructContents(ionStructOf(field("foo", ionInt(12))))
+        assertStructContents(ionStructOf(listOf(field("foo", ionInt(12)))))
+    }
+
+    private fun assertStructContents(struct: StructElement) {
+        assertEquals(1, struct.size)
+        assertEquals(12L, struct["foo"].longValue)
+    }
+
+}


### PR DESCRIPTION
Implements #6.  Also decided that every constructor needs annotations too.

- Also add tests.
- Fix one bug discovered as result of tests.

You'll also find that I removed a lot of default values for implementation constructors' annotations and metas parameters.  This was to avoid accidentally forgetting to specify these when being invoked by the top-level constructor functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
