### PR TITLE
Change receiver type of `toIonValue` to `IonElement`

### DIFF
--- a/src/com/amazon/ionelement/api/IonUtils.kt
+++ b/src/com/amazon/ionelement/api/IonUtils.kt
@@ -26,7 +26,7 @@ import com.amazon.ion.IonValue
  *
  * New code that doesn't need to integrate with existing uses of the mutable DOM should not use this.
  */
-fun AnyElement.toIonValue(ion: IonSystem): IonValue {
+fun IonElement.toIonValue(ion: IonSystem): IonValue {
     val datagram = ion.newDatagram()
     ion.newWriter(datagram).use { writer ->
         this.writeTo(writer)


### PR DESCRIPTION
A mild annoyance is that the [`toIonValue()` extension function](https://github.com/amzn/ion-element-kotlin/blob/7c5d328f86611f0a39112863f1ef64e40b7208a8/src/com/amazon/ionelement/api/IonUtils.kt#L29) has `AnyElement` as it's receiver type.  This means that in order to convert a non `AnyElement` `IonElement` to the legacy `IonValue` DOM, one must first call `asAnyElement()` on it.

Changing the reciever type to `IonElement` eliminates the need to do that without breaking source compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
