### PR TITLE
Include the element to blame for IonElementConstraintExceptions

### DIFF
--- a/src/com/amazon/ionelement/api/IonElementException.kt
+++ b/src/com/amazon/ionelement/api/IonElementException.kt
@@ -31,9 +31,13 @@ class IonElementLoaderException(
     cause: Throwable? = null
 ) : IonElementException(location, description, cause)
 
-/** Exception thrown by [IonElement] accessor functions to indicate a type or nullness constraint has been violated. */
+/**
+ * Exception thrown by [IonElement] accessor functions to indicate a type or nullness constraint has been violated.
+ *
+ * [blame] is the [IonElement] instance that violates the constraint.
+ */
 class IonElementConstraintException(
-    location: IonLocation?,
+    val blame: IonElement,
     description: String,
     cause: Throwable? = null
-) : IonElementException(location, description, cause)
+) : IonElementException(blame.metas.location, description, cause)

--- a/src/com/amazon/ionelement/api/IonElementException.kt
+++ b/src/com/amazon/ionelement/api/IonElementException.kt
@@ -37,7 +37,9 @@ class IonElementLoaderException(
  * [blame] is the [IonElement] instance that violates the constraint.
  */
 class IonElementConstraintException(
-    val blame: IonElement,
+    private val elementToBlame: IonElement,
     description: String,
     cause: Throwable? = null
-) : IonElementException(blame.metas.location, description, cause)
+) : IonElementException(elementToBlame.metas.location, description, cause) {
+    val blame get() = elementToBlame.asAnyElement()
+}

--- a/src/com/amazon/ionelement/api/IonUtils.kt
+++ b/src/com/amazon/ionelement/api/IonUtils.kt
@@ -46,6 +46,6 @@ fun IonValue.toIonElement(): AnyElement =
 
 /** Throws an [IonElementException], including the [IonLocation] (if available). */
 internal fun constraintError(blame: IonElement, description: String): Nothing {
-    throw IonElementConstraintException(blame, description)
+    throw IonElementConstraintException(blame.asAnyElement(), description)
 }
 

--- a/src/com/amazon/ionelement/api/IonUtils.kt
+++ b/src/com/amazon/ionelement/api/IonUtils.kt
@@ -46,10 +46,6 @@ fun IonValue.toIonElement(): AnyElement =
 
 /** Throws an [IonElementException], including the [IonLocation] (if available). */
 internal fun constraintError(blame: IonElement, description: String): Nothing {
-    constraintError(blame.metas, description)
+    throw IonElementConstraintException(blame, description)
 }
 
-/** Throws an [IonElementException], including the [IonLocation] (if available). */
-internal fun constraintError(metas: MetaContainer, description: String): Nothing {
-    throw IonElementConstraintException(metas.location, description)
-}


### PR DESCRIPTION
This isn't API breaking, assuming nobody is throwing `IonElementConstraintException` in client code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
