### PR TITLE
Add `bigIntegerValue` impl for `LongIntElementImpl`

### DIFF
--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -20,7 +20,7 @@ import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.IntElement
 import com.amazon.ionelement.api.IntElementSize
 import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
+import java.math.BigInteger
 
 internal class LongIntElementImpl(
     override val longValue: Long,
@@ -29,6 +29,8 @@ internal class LongIntElementImpl(
 ) : AnyElementBase(), IntElement {
     override val integerSize: IntElementSize get() = IntElementSize.LONG
     override val type: ElementType get() = ElementType.INT
+
+    override val bigIntegerValue: BigInteger get() = BigInteger.valueOf(longValue)
 
     override fun copy(annotations: List<String>, metas: MetaContainer): IntElement =
         LongIntElementImpl(longValue, annotations, metas)

--- a/test/com/amazon/ionelement/AnyElementTests.kt
+++ b/test/com/amazon/ionelement/AnyElementTests.kt
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import java.math.BigInteger
 
 class AnyElementTests {
     @ParameterizedTest
@@ -57,6 +58,16 @@ class AnyElementTests {
         assertEquals(2, s.count())
         s.single { it.name == "foo" && it.value.longValue == 1L}
         s.single { it.name == "bar" && it.value.longValue == 2L}
+    }
+
+    @Test
+    fun bigIntegerValueFromLongIntElement() {
+        val longValues = listOf(1, 0, -1, Long.MIN_VALUE, Long.MAX_VALUE)
+        longValues.map {
+            val bigInt = loadSingleElement(it.toString())
+            val bigIntValue = bigInt.bigIntegerValue
+            assertEquals(BigInteger.valueOf(it), bigIntValue)
+        }
     }
 
     companion object {


### PR DESCRIPTION
Fixes #48.

Implements `AnyElement.bigIntegerValue` for `LongIntElementImpl`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

