### PR TITLE
Update project to use gradle 6.8.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,12 +65,12 @@ dokka {
 
 task sourcesJar(type: Jar) {
     from "src"
-    classifier = "sources"
+    archiveClassifier.set("sources")
 }
 
 task javadocJar(type: Jar) {
     from dokka
-    classifier = "javadoc"
+    archiveClassifier.set("javadoc")
 }
 
 java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
-#Thu Apr 30 19:09:26 PDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+#Mon Mar 29 11:55:05 PDT 2021
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

Update the gradle wrapper to use gradle 6.8.3, and updates usage of a deprecated field in the build script with the approved replacement.

This PR helps to unblock the resolution of #46. For Kotlin 1.4, the compileKotlin gradle plugin requires a gradle version >= 6.



_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

