### PR TITLE
Adds kotlinx.collections.immutable to ensure immutability of the contents of a ContainerElement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
     api 'com.amazon.ion:ion-java:[1.4.0,)'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.4'
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'

--- a/src/com/amazon/ionelement/api/Ion.kt
+++ b/src/com/amazon/ionelement/api/Ion.kt
@@ -34,7 +34,11 @@ import com.amazon.ionelement.impl.StructElementImpl
 import com.amazon.ionelement.impl.StructFieldImpl
 import com.amazon.ionelement.impl.SymbolElementImpl
 import com.amazon.ionelement.impl.TimestampElementImpl
+import kotlinx.collections.immutable.PersistentList
 import java.math.BigInteger
+
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 typealias Annotations = List<String>
 
@@ -123,8 +127,8 @@ fun ionString(
     metas: MetaContainer = emptyMetaContainer()
 ): StringElement = StringElementImpl(
     value = s,
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 /** Creates a [StringElement] that represents an Ion `symbol`. */
 fun ionString(
@@ -140,8 +144,8 @@ fun ionSymbol(
     metas: MetaContainer = emptyMetaContainer()
 ): SymbolElement = SymbolElementImpl(
     value = s,
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 
 /** Creates a [SymbolElement] that represents an Ion `symbol`. */
@@ -158,8 +162,8 @@ fun ionTimestamp(
     metas: MetaContainer = emptyMetaContainer()
 ): TimestampElement = TimestampElementImpl(
     timestampValue = Timestamp.valueOf(s),
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
@@ -176,8 +180,8 @@ fun ionTimestamp(
     metas: MetaContainer = emptyMetaContainer()
 ): TimestampElement = TimestampElementImpl(
     timestampValue = timestamp,
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
@@ -195,8 +199,8 @@ fun ionInt(
 ): IntElement =
     LongIntElementImpl(
         longValue = l,
-        annotations = annotations,
-        metas = metas
+        annotations = annotations.toPersistentList(),
+        metas = metas.toPersistentMap()
     )
 
 /** Creates an [IntElement] that represents an Ion `int`. */
@@ -213,8 +217,8 @@ fun ionInt(
     metas: MetaContainer = emptyMetaContainer()
 ): IntElement = BigIntIntElementImpl(
     bigIntegerValue = bigInt,
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 
 /** Creates an [IntElement] that represents an Ion `BitInteger`. */
@@ -231,8 +235,8 @@ fun ionBool(
     metas: MetaContainer = emptyMetaContainer()
 ): BoolElement = BoolElementImpl(
     booleanValue = b,
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 
 /** Creates a [BoolElement] that represents an Ion `bool`. */
@@ -249,8 +253,8 @@ fun ionFloat(
     metas: MetaContainer = emptyMetaContainer()
 ): FloatElement = FloatElementImpl(
     doubleValue = d,
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 
 /** Creates a [FloatElement] that represents an Ion `float`. */
@@ -267,8 +271,8 @@ fun ionDecimal(
     metas: MetaContainer = emptyMetaContainer()
 ): DecimalElement = DecimalElementImpl(
     decimalValue = bigDecimal,
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 
 /** Creates a [DecimalElement] that represents an Ion `decimall`. */
@@ -289,8 +293,8 @@ fun ionBlob(
     metas: MetaContainer = emptyMetaContainer()
 ): BlobElement = BlobElementImpl(
     bytes = bytes.clone(),
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 
 /**
@@ -318,8 +322,8 @@ fun ionClob(
     metas: MetaContainer = emptyMetaContainer()
 ): ClobElement = ClobElementImpl(
     bytes = bytes.clone(),
-    annotations = annotations,
-    metas = metas
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
 )
 /**
  * Creates a [ClobElement] that represents an Ion `clob`.
@@ -342,9 +346,9 @@ fun ionListOf(
     metas: MetaContainer = emptyMetaContainer()
 ): ListElement =
     ListElementImpl(
-        values = iterable.map { it.asAnyElement() },
-        annotations = annotations,
-        metas = metas
+        values = iterable.map { it.asAnyElement() }.toPersistentList(),
+        annotations = annotations.toPersistentList(),
+        metas = metas.toPersistentMap()
     )
 
 /** Creates a [ListElement] that represents an Ion `list`. */
@@ -391,9 +395,9 @@ fun ionSexpOf(
     metas: MetaContainer = emptyMetaContainer()
 ): SexpElement =
     SexpElementImpl(
-        values = iterable.map { it.asAnyElement() },
-        annotations = annotations,
-        metas = metas
+        values = iterable.map { it.asAnyElement() }.toPersistentList(),
+        annotations = annotations.toPersistentList(),
+        metas = metas.toPersistentMap()
     )
 
 /** Creates an [SexpElement] that represents an Ion `sexp`. */
@@ -433,9 +437,9 @@ fun ionStructOf(
     metas: MetaContainer = emptyMetaContainer()
 ): StructElement =
     StructElementImpl(
-        allFields = fields.toList(),
-        annotations = annotations,
-        metas = metas
+        allFields = fields.toPersistentList(),
+        annotations = annotations.toPersistentList(),
+        metas = metas.toPersistentMap()
     )
 
 /** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
@@ -453,7 +457,7 @@ fun ionStructOf(
 ): StructElement =
     ionStructOf(
         fields = fields.asIterable(),
-        annotations = annotations,
+        annotations = annotations.toPersistentList(),
         metas = metas
     )
 
@@ -470,14 +474,17 @@ fun ionStructOf(
         metas
     )
 
+// Memoized empty PersistentList for the memoized container types and null values
+private val EMPTY_PERSISTENT_LIST: PersistentList<Nothing> = emptyList<Nothing>().toPersistentList()
+
 // Memoized empty instances of our container types.
-private val EMPTY_LIST = ListElementImpl(emptyList(), emptyList(), emptyMetaContainer())
-private val EMPTY_SEXP = SexpElementImpl(emptyList(), emptyList(), emptyMetaContainer())
-private val EMPTY_STRUCT = StructElementImpl(emptyList(), emptyList(), emptyMetaContainer())
-private val EMPTY_BLOB = BlobElementImpl(ByteArray(0), emptyList(), emptyMetaContainer())
-private val EMPTY_CLOB = ClobElementImpl(ByteArray(0), emptyList(), emptyMetaContainer())
+private val EMPTY_LIST = ListElementImpl(EMPTY_PERSISTENT_LIST, EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+private val EMPTY_SEXP = SexpElementImpl(EMPTY_PERSISTENT_LIST, EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+private val EMPTY_STRUCT = StructElementImpl(EMPTY_PERSISTENT_LIST, EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+private val EMPTY_BLOB = BlobElementImpl(ByteArray(0), EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+private val EMPTY_CLOB = ClobElementImpl(ByteArray(0), EMPTY_PERSISTENT_LIST, EMPTY_METAS)
 
 // Memoized instances of all of our null values.
 private val ALL_NULLS = ElementType.values().map {
-    it to NullElementImpl(it, emptyList(), emptyMetaContainer()) as IonElement
+    it to NullElementImpl(it, EMPTY_PERSISTENT_LIST, EMPTY_METAS) as IonElement
 }.toMap()

--- a/src/com/amazon/ionelement/api/IonMeta.kt
+++ b/src/com/amazon/ionelement/api/IonMeta.kt
@@ -16,9 +16,13 @@
 @file: JvmName("IonMeta")
 package com.amazon.ionelement.api
 
-typealias MetaContainer = Map<String, Any>
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.toPersistentHashMap
 
-private val EMPTY_METAS = HashMap<String, Any>()
+typealias MetaContainer = Map<String, Any>
+internal typealias PersistentMetaContainer = PersistentMap<String, Any>
+
+internal val EMPTY_METAS = HashMap<String, Any>().toPersistentHashMap()
 
 fun emptyMetaContainer(): MetaContainer = EMPTY_METAS
 

--- a/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
@@ -21,14 +21,18 @@ import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.IntElement
 import com.amazon.ionelement.api.IntElementSize
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.constraintError
 import com.amazon.ionelement.api.emptyMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import java.math.BigInteger
 
 internal class BigIntIntElementImpl(
     override val bigIntegerValue: BigInteger,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ) : AnyElementBase(), IntElement {
 
     override val type: ElementType get() = ElementType.INT
@@ -43,7 +47,7 @@ internal class BigIntIntElementImpl(
     }
 
     override fun copy(annotations: List<String>, metas: MetaContainer): IntElement =
-        BigIntIntElementImpl(bigIntegerValue, annotations, metas)
+        BigIntIntElementImpl(bigIntegerValue, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeInt(bigIntegerValue)
 

--- a/src/com/amazon/ionelement/impl/BlobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BlobElementImpl.kt
@@ -21,10 +21,15 @@ import com.amazon.ionelement.api.ByteArrayView
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
 
+import com.amazon.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
 internal class BlobElementImpl(
     bytes: ByteArray,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ) : LobElementBase(bytes), BlobElement {
 
     override val blobValue: ByteArrayView get() = bytesValue
@@ -32,7 +37,7 @@ internal class BlobElementImpl(
     override fun writeContentTo(writer: IonWriter) = writer.writeBlob(bytes)
 
     override fun copy(annotations: List<String>, metas: MetaContainer): BlobElement =
-        BlobElementImpl(bytes, annotations, metas)
+        BlobElementImpl(bytes, annotations.toPersistentList(), metas.toPersistentMap())
 
     override val type: ElementType get() = ElementType.BLOB
 }

--- a/src/com/amazon/ionelement/impl/BoolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BoolElementImpl.kt
@@ -19,17 +19,21 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.BoolElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class BoolElementImpl(
     override val booleanValue: Boolean,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ): AnyElementBase(), BoolElement {
     override val type: ElementType get() = ElementType.BOOL
 
     override fun copy(annotations: List<String>, metas: MetaContainer): BoolElement =
-        BoolElementImpl(booleanValue, annotations, metas)
+        BoolElementImpl(booleanValue, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeBool(booleanValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/ClobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ClobElementImpl.kt
@@ -20,19 +20,24 @@ import com.amazon.ionelement.api.ByteArrayView
 import com.amazon.ionelement.api.ClobElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
+
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class ClobElementImpl(
     bytes: ByteArray,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ) : LobElementBase(bytes), ClobElement {
 
     override val clobValue: ByteArrayView get() = bytesValue
 
     override fun writeContentTo(writer: IonWriter) = writer.writeClob(bytes)
     override fun copy(annotations: List<String>, metas: MetaContainer): ClobElement =
-        ClobElementImpl(bytes, annotations, metas)
+        ClobElementImpl(bytes, annotations.toPersistentList(), metas.toPersistentMap())
 
     override val type: ElementType get() = ElementType.CLOB
 }

--- a/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
@@ -20,17 +20,22 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.DecimalElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
+
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class DecimalElementImpl(
     override val decimalValue: Decimal,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ) : AnyElementBase(), DecimalElement {
     override val type get() = ElementType.DECIMAL
 
     override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElement =
-        DecimalElementImpl(decimalValue, annotations, metas)
+        DecimalElementImpl(decimalValue, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeDecimal(decimalValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/FloatElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/FloatElementImpl.kt
@@ -19,17 +19,22 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.FloatElement
 import com.amazon.ionelement.api.MetaContainer
+
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class FloatElementImpl(
     override val doubleValue: Double,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ) : AnyElementBase(), FloatElement {
     override val type: ElementType get() = ElementType.FLOAT
 
     override fun copy(annotations: List<String>, metas: MetaContainer): FloatElement =
-        FloatElementImpl(doubleValue, annotations, metas)
+        FloatElementImpl(doubleValue, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeFloat(doubleValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/ListElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ListElementImpl.kt
@@ -19,18 +19,22 @@ import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.ListElement
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class ListElementImpl (
-    values: List<AnyElement>,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    values: PersistentList<AnyElement>,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ): SeqElementBase(values), ListElement {
     override val type: ElementType get() = ElementType.LIST
 
     override val listValues: List<AnyElement> get() = values
 
     override fun copy(annotations: List<String>, metas: MetaContainer): ListElement =
-        ListElementImpl(values, annotations, metas)
+        ListElementImpl(values, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -20,12 +20,16 @@ import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.IntElement
 import com.amazon.ionelement.api.IntElementSize
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import java.math.BigInteger
 
 internal class LongIntElementImpl(
     override val longValue: Long,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ) : AnyElementBase(), IntElement {
     override val integerSize: IntElementSize get() = IntElementSize.LONG
     override val type: ElementType get() = ElementType.INT
@@ -33,7 +37,7 @@ internal class LongIntElementImpl(
     override val bigIntegerValue: BigInteger get() = BigInteger.valueOf(longValue)
 
     override fun copy(annotations: List<String>, metas: MetaContainer): IntElement =
-        LongIntElementImpl(longValue, annotations, metas)
+        LongIntElementImpl(longValue, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeInt(longValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/NullElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/NullElementImpl.kt
@@ -19,18 +19,22 @@ import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class NullElementImpl(
     override val type: ElementType = ElementType.NULL,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ): AnyElementBase() {
 
     override val isNull: Boolean get() = true
 
     override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement =
-        NullElementImpl(type, annotations, metas)
+        NullElementImpl(type, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeNull(type.toIonType())
 

--- a/src/com/amazon/ionelement/impl/SeqElementBase.kt
+++ b/src/com/amazon/ionelement/impl/SeqElementBase.kt
@@ -18,9 +18,10 @@ package com.amazon.ionelement.impl
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.SeqElement
+import kotlinx.collections.immutable.PersistentList
 
 internal abstract class SeqElementBase(
-    override val values: List<AnyElement>
+    override val values: PersistentList<AnyElement>
 ): AnyElementBase(), SeqElement {
 
     override val containerValues: List<AnyElement> get() = values

--- a/src/com/amazon/ionelement/impl/SexpElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SexpElementImpl.kt
@@ -18,19 +18,23 @@ package com.amazon.ionelement.impl
 import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.SexpElement
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class SexpElementImpl (
-    values: List<AnyElement>,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    values: PersistentList<AnyElement>,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ):  SeqElementBase(values), SexpElement {
     override val type: ElementType get() = ElementType.SEXP
 
     override val sexpValues: List<AnyElement> get() = seqValues
 
     override fun copy(annotations: List<String>, metas: MetaContainer): SexpElement =
-        SexpElementImpl(values, annotations, metas)
+        SexpElementImpl(values, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/com/amazon/ionelement/impl/StringElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StringElementImpl.kt
@@ -18,19 +18,23 @@ package com.amazon.ionelement.impl
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.StringElement
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class StringElementImpl(
     value: String,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ): TextElementBase(value), StringElement {
     override val type: ElementType get() = ElementType.STRING
 
     override val stringValue: String get() = textValue
 
     override fun copy(annotations: List<String>, metas: MetaContainer): StringElement =
-        StringElementImpl(textValue, annotations, metas)
+        StringElementImpl(textValue, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeString(textValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
@@ -18,20 +18,24 @@ package com.amazon.ionelement.impl
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.SymbolElement
 import com.amazon.ionelement.api.emptyMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class SymbolElementImpl(
     value: String,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ): TextElementBase(value), SymbolElement {
     override val type: ElementType get() = ElementType.SYMBOL
 
     override val symbolValue: String get() = textValue
 
     override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElement =
-        SymbolElementImpl(textValue, annotations, metas)
+        SymbolElementImpl(textValue, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeSymbol(textValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
@@ -19,17 +19,21 @@ import com.amazon.ion.IonWriter
 import com.amazon.ion.Timestamp
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.TimestampElement
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 
 internal class TimestampElementImpl(
     override val timestampValue: Timestamp,
-    override val annotations: List<String>,
-    override val metas: MetaContainer
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
 ): AnyElementBase(), TimestampElement {
 
     override val type: ElementType get() = ElementType.TIMESTAMP
     override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElement =
-        TimestampElementImpl(timestampValue, annotations, metas)
+        TimestampElementImpl(timestampValue, annotations.toPersistentList(), metas.toPersistentMap())
 
     override fun writeContentTo(writer: IonWriter) = writer.writeTimestamp(timestampValue)
 

--- a/test/com/amazon/ionelement/ImmutabilityTests.java
+++ b/test/com/amazon/ionelement/ImmutabilityTests.java
@@ -1,0 +1,157 @@
+package com.amazon.ionelement;
+
+import com.amazon.ion.Decimal;
+import com.amazon.ion.Timestamp;
+import com.amazon.ionelement.api.*;
+import kotlin.Pair;
+import kotlinx.collections.immutable.PersistentList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.amazon.ionelement.api.Ion.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * This particular test class is written in Java because the {@link List} interface is immutable in Kotlin,
+ * and immutability is enforced in the type system (rather than at runtime). In Java, we have no such
+ * limitation and can attempt to modify any {@link List} without getting any complaint from the compiler.
+ */
+public class ImmutabilityTests {
+
+
+    @SafeVarargs
+    private static <E> List<E> listOf(E... elements) {
+        ArrayList<E> arrayList = new ArrayList<>();
+        Collections.addAll(arrayList, elements);
+        return arrayList;
+    }
+
+    private static Map<String, Object> dummyMetas() {
+        return IonMeta.metaContainerOf(listOf(new Pair<>("foo_meta", 1)));
+    }
+
+    private static List<String> dummyAnnotations() {
+        return listOf("some_annotation");
+    }
+
+    static List<Object> parametersForMetasAndAnnotationsTests() {
+        return listOf(
+                ionNull(ElementType.NULL, dummyAnnotations(), dummyMetas()),
+                ionBool(true, dummyAnnotations(), dummyMetas()),
+                ionInt(123L, dummyAnnotations(), dummyMetas()),
+                ionInt(BigInteger.ONE, dummyAnnotations(), dummyMetas()),
+                ionTimestamp("2001T", dummyAnnotations(), dummyMetas()),
+                ionTimestamp(Timestamp.valueOf("2001T"), dummyAnnotations(), dummyMetas()),
+                ionFloat(1.0, dummyAnnotations(), dummyMetas()),
+                ionDecimal(Decimal.ZERO, dummyAnnotations(), dummyMetas()),
+                ionString("foo", dummyAnnotations(), dummyMetas()),
+                ionSymbol("foo", dummyAnnotations(), dummyMetas()),
+                ionClob(new byte[]{1}, dummyAnnotations(), dummyMetas()),
+                ionBlob(new byte[]{1}, dummyAnnotations(), dummyMetas()),
+                ionListOf(listOf(ionInt(1)), dummyAnnotations(), dummyMetas()),
+                ionSexpOf(listOf(ionInt(1)), dummyAnnotations(), dummyMetas()),
+                ionStructOf(listOf(field("foo", ionInt(1))), dummyAnnotations(), dummyMetas())
+        );
+    }
+
+    @ParameterizedTest(name = "annotationsAreImmutable: {0}")
+    @MethodSource("parametersForMetasAndAnnotationsTests")
+    public void annotationsAreImmutable(IonElement elem) {
+        // Assert that attempting to modify the annotations throws an UnsupportedOperationException
+        try {
+            elem.getAnnotations().add("foo");
+            fail("Expected an exception to be thrown when trying to modify the annotations.");
+        } catch (UnsupportedOperationException e) {
+            // Pass
+        }
+    }
+
+    @ParameterizedTest(name = "metasAreImmutable: {0}")
+    @MethodSource("parametersForMetasAndAnnotationsTests")
+    public void metasAreImmutable(IonElement elem) {
+        // Assert that attempting to modify the metas throws an UnsupportedOperationException
+        try {
+            elem.getMetas().put("foo", "bar");
+            fail("Expected an exception to be thrown when trying to modify the metas.");
+        } catch (UnsupportedOperationException e) {
+            // Pass
+        }
+    }
+    
+    @Test
+    public void listElementValuesAreImmutable() {
+        StringElement foo = ionString("foo");
+        StringElement bar = ionString("bar");
+        StringElement baz = ionString("baz");
+
+        List<IonElement> listValues = listOf(foo, bar);
+
+        ListElement ionList = ionListOf(listValues);
+
+        // Assert that modifying the original collection does not modify the values in the ListElement
+        listValues.add(baz);
+        assertEquals(listOf(foo, bar), ionList.getValues());
+
+        // Assert that attempting to modify the values in the ListElement throws an UnsupportedOperationException
+        try {
+            ionList.getValues().add(baz.asAnyElement());
+            fail("Expected an exception to be thrown when trying to modify the contents of the ListElement values.");
+        } catch (UnsupportedOperationException e) {
+            // Pass
+        }
+    }
+
+    @Test
+    public void sexpElementValuesAreImmutable() {
+        StringElement foo = ionString("foo");
+        StringElement bar = ionString("bar");
+        StringElement baz = ionString("baz");
+
+        List<IonElement> sexpValues = listOf(foo, bar);
+
+        SexpElement ionSexp = ionSexpOf(sexpValues);
+
+        // Assert that modifying the original collection does not modify the values in the SexpElement
+        sexpValues.add(baz);
+        assertEquals(listOf(foo, bar), ionSexp.getValues());
+
+        // Assert that attempting to modify the values in the SexpElement throws an UnsupportedOperationException
+        try {
+            ionSexp.getValues().add(baz.asAnyElement());
+            fail("Expected an exception to be thrown when trying to modify the contents of the SexpElement values.");
+        } catch (UnsupportedOperationException e) {
+            // Pass
+        }
+    }
+
+    @Test
+    public void structElementValuesAreImmutable() {
+        StructField foo = field("foo", ionString("foo"));
+        StructField bar = field("bar", ionString("bar"));
+        StructField baz = field("baz", ionString("baz"));
+
+        List<StructField> structValues = listOf(foo, bar);
+
+        StructElement ionStruct = ionStructOf(structValues);
+
+        // Assert that modifying the original collection does not modify the fields in the StructElement
+        structValues.add(baz);
+        assertEquals(listOf(foo, bar), ionStruct.getFields());
+
+        // Assert that attempting to modify the fields in the StructElement throws an UnsupportedOperationException
+        try {
+            ionStruct.getFields().add(baz);
+            fail("Expected an exception to be thrown when trying to modify the contents of the StructElement fields.");
+        } catch (UnsupportedOperationException e) {
+            // Pass
+        }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

Fixes #45 

**Description of changes:**

Makes the backing `List` of all of the container types immutable, even from Java code.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

