### PR TITLE
Add componentN() functions to StructField

### DIFF
--- a/src/com/amazon/ionelement/api/StructField.kt
+++ b/src/com/amazon/ionelement/api/StructField.kt
@@ -21,5 +21,8 @@ package com.amazon.ionelement.api
 interface StructField {
     val name: String
     val value: AnyElement
+
+    operator fun component1(): String
+    operator fun component2(): AnyElement
 }
 

--- a/test/com/amazon/ionelement/StructIonElementTests.kt
+++ b/test/com/amazon/ionelement/StructIonElementTests.kt
@@ -83,8 +83,8 @@ class StructIonElementTests {
     }
 
 
-    private fun Iterable<StructField>.assertHasField(fieldName: String, value: IonElement) {
-        assertTrue(this.any { it.name == fieldName && it.value == value }, "Must have field '$fieldName'")
+    private fun Iterable<StructField>.assertHasField(expectedName: String, expectedValue: IonElement) {
+        assertTrue(this.any { (name, value) -> name == expectedName && value == expectedValue }, "Must have field '$expectedName'")
     }
 
 }


### PR DESCRIPTION

**Issue #, if available:**

N/A

**Description of changes:**

Adds `componentN()` functions to the `StructField` interface so that we can use [destructuring declarations](https://kotlinlang.org/docs/destructuring-declarations.html) on `StructField`s.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

