### PR TITLE
Fix broken Github Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,9 @@ jobs:
 
       steps:
         - name: Check out code 
-          uses: actions/checkout@v2.0.0
-
-        - name: Check out submodules
-          uses: textbook/git-checkout-submodule-action@2.0.0
+          uses: actions/checkout@v2
+          with:
+            submodules: recursive
 
         - name: Setup java ${{ matrix.java }}
           uses: actions/setup-java@v1

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -9,10 +9,9 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2.0.0
-
-      - name: Check out submodules
-        uses: textbook/git-checkout-submodule-action@2.0.0
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Setup java ${{ matrix.java }}
         uses: actions/setup-java@v1


### PR DESCRIPTION

**Issue #, if available:**

N/A

**Description of changes:**

There was some 3rd party GH Action being used to checkout the git submodules, and that particular step no longer works. (See [this failed workflow step](https://github.com/amzn/ion-element-kotlin/runs/4890567083?check_suite_focus=true#step:2:1), for example.) This change replaces the 3rd party step with the option to perform a recursive checkout in the github-provided action.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

