### PR TITLE
Make `IonElement.toIonValue` accept a ValueFactory instance instead of IonSystem

### DIFF
--- a/test/com/amazon/ionelement/ToIonValueTests.kt
+++ b/test/com/amazon/ionelement/ToIonValueTests.kt
@@ -1,0 +1,24 @@
+package com.amazon.ionelement
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionelement.api.toIonElement
+import com.amazon.ionelement.api.toIonValue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ToIonValueTests {
+
+    /**
+     * This test is needed due to the way `IonElement.toIonValue(ValueFactory)` uses a temporary container to obtain
+     * an `IonWriter` implementation to which the receiver will be written.
+     */
+    @Test
+    fun `IonValue instances converted from IonElement instances can be added to IonContainer instances`() {
+        val ion = IonSystemBuilder.standard().build()
+        val ionValue = ion.singleValue("1")
+        val element = ionValue.toIonElement()
+        val ionList = ion.newList(element.toIonValue(ion))
+
+        assertEquals(ion.singleValue("[1]"), ionList);
+    }
+}


### PR DESCRIPTION
This minor backward compatible API change eliminates an unfortunate dependency on `IonSystem`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

