### PR TITLE
Explicitly specify return types for 3 public functions

### DIFF
--- a/src/com/amazon/ionelement/api/IonElementLoader.kt
+++ b/src/com/amazon/ionelement/api/IonElementLoader.kt
@@ -90,17 +90,17 @@ data class IonElementLoaderOptions(
 
 /** Creates an [IonElementLoader] implementation with the specified [options]. */
 @JvmOverloads
-fun createIonElementLoader(options: IonElementLoaderOptions = IonElementLoaderOptions()) =
+fun createIonElementLoader(options: IonElementLoaderOptions = IonElementLoaderOptions()): IonElementLoader =
     IonElementLoaderImpl(options)
 
 /** Provides syntactically lighter way of invoking [IonElementLoader.loadSingleElement]. */
 @JvmOverloads
-fun loadSingleElement(ionText: String, options: IonElementLoaderOptions = IonElementLoaderOptions()) =
+fun loadSingleElement(ionText: String, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
     createIonElementLoader(options).loadSingleElement(ionText)
 
 /** Provides syntactically lighter method of invoking [IonElementLoader.loadSingleElement]. */
 @JvmOverloads
-fun loadSingleElement(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()) =
+fun loadSingleElement(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
     createIonElementLoader(options).loadSingleElement(ionReader)
 
 /** Provides syntactically lighter method of invoking [IonElementLoader.loadAllElements]. */


### PR DESCRIPTION
This is just a little API cleanup.

Most importantly, `createIonElementLoader` used to have its return type implicitly defined and by accident it was `IonElementLoaderImpl` when it should have been `IonElementLoader`.

The return types of the other functions were implicitly `AnyElement`, but this should be explict for best practices, so I specified their return types as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

