### PR TITLE
Adds function to check if a field name is present in a struct

### DIFF
--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -307,5 +307,8 @@ interface StructElement : ContainerElement {
     /** Retrieves all values with a given field name. Returns an empty iterable if the field does not exist. */
     fun getAll(fieldName: String): Iterable<AnyElement>
 
+    /** Returns true if this StructElement has at least one field with the given field name. */
+    fun containsField(fieldName: String): Boolean
+
     override fun copy(annotations: List<String>, metas: MetaContainer): StructElement
 }

--- a/src/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -79,6 +79,8 @@ internal class StructElementImpl(
 
     override fun getAll(fieldName: String): Iterable<AnyElement> = fieldsByName[fieldName] ?: emptyList()
 
+    override fun containsField(fieldName: String): Boolean = fieldsByName.containsKey(fieldName)
+
     override fun copy(annotations: List<String>, metas: MetaContainer): StructElement =
         StructElementImpl(allFields, annotations.toPersistentList(), metas.toPersistentMap())
 

--- a/test/com/amazon/ionelement/StructIonElementTests.kt
+++ b/test/com/amazon/ionelement/StructIonElementTests.kt
@@ -21,6 +21,7 @@ import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.loadSingleElement
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -82,6 +83,12 @@ class StructIonElementTests {
             "null is returned when the field is not present.")
     }
 
+    @Test
+    fun containsField() {
+        assertTrue(struct.containsField("a"))
+        assertTrue(struct.containsField("b"))
+        assertFalse(struct.containsField("z"))
+    }
 
     private fun Iterable<StructField>.assertHasField(expectedName: String, expectedValue: IonElement) {
         assertTrue(this.any { (name, value) -> name == expectedName && value == expectedValue }, "Must have field '$expectedName'")


### PR DESCRIPTION
#### Issue #, if available:

Fixes #41 

#### Description of changes:

Adds `containsField(fieldName: String): Boolean` function to `StructElement`. This function is essentially like `containsKey` from the `Map` interface.



_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

