### PR TITLE
Makes the `with*` functions callable from Java

### DIFF
--- a/src/com/amazon/ionelement/api/AnyElement.kt
+++ b/src/com/amazon/ionelement/api/AnyElement.kt
@@ -352,4 +352,11 @@ interface AnyElement : IonElement {
     /** See [AnyElement]. */
     val structFieldsOrNull: Collection<StructField>?
 
+    override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement
+    override fun withAnnotations(vararg additionalAnnotations: String): AnyElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): AnyElement
+    override fun withoutAnnotations(): AnyElement
+    override fun withMetas(additionalMetas: MetaContainer): AnyElement
+    override fun withMeta(key: String, value: Any): AnyElement
+    override fun withoutMetas(): AnyElement
 }

--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -95,6 +95,12 @@ interface IonElement {
     /** Converts the current element to Ion text. */
     override fun toString(): String
 
+    /*
+     * The following `with*` mutators are repeated on every sub-interface because any approach using generics that is
+     * ergonomic for Java code results in conflicting function declarations for classes that both extend AnyElementBase
+     * and implement a type-specific sub-interface of IonElement.
+     */
+
     /** Returns a shallow copy of the current node with the specified additional annotations. */
     fun withAnnotations(vararg additionalAnnotations: String): IonElement
 

--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -94,19 +94,57 @@ interface IonElement {
 
     /** Converts the current element to Ion text. */
     override fun toString(): String
-}
 
+    /** Returns a shallow copy of the current node with the specified additional annotations. */
+    fun withAnnotations(vararg additionalAnnotations: String): IonElement
+
+    /** Returns a shallow copy of the current node with the specified additional annotations. */
+    fun withAnnotations(additionalAnnotations: Iterable<String>): IonElement
+
+    /** Returns a shallow copy of the current node with all annotations removed. */
+    fun withoutAnnotations(): IonElement
+
+    /**
+     * Returns a shallow copy of the current node with the specified additional metadata, overwriting any metas
+     * that already exist with the same keys.
+     */
+    fun withMetas(additionalMetas: MetaContainer): IonElement
+
+    /**
+     * Returns a shallow copy of the current node with the specified additional meta, overwriting any meta
+     * that previously existed with the same key.
+     *
+     * When adding multiple metas, consider [withMetas] instead.
+     */
+    fun withMeta(key: String, value: Any): IonElement
+
+    /** Returns a shallow copy of the current node without any metadata. */
+    fun withoutMetas(): IonElement
+}
 
 /** Represents a Ion bool. */
 interface BoolElement : IonElement {
     val booleanValue: Boolean
     override fun copy(annotations: List<String>, metas: MetaContainer): BoolElement
+    override fun withAnnotations(vararg additionalAnnotations: String): BoolElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BoolElement
+    override fun withoutAnnotations(): BoolElement
+    override fun withMetas(additionalMetas: MetaContainer): BoolElement
+    override fun withMeta(key: String, value: Any): BoolElement
+    override fun withoutMetas(): BoolElement
 }
 
 /** Represents a Ion timestamp. */
 interface TimestampElement : IonElement {
     val timestampValue: Timestamp
     override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): TimestampElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): TimestampElement
+    override fun withoutAnnotations(): TimestampElement
+    override fun withMetas(additionalMetas: MetaContainer): TimestampElement
+    override fun withMeta(key: String, value: Any): TimestampElement
+    override fun withoutMetas(): TimestampElement
 }
 
 
@@ -136,12 +174,26 @@ interface IntElement : IonElement {
      */
     val bigIntegerValue: BigInteger
     override fun copy(annotations: List<String>, metas: MetaContainer): IntElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): IntElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): IntElement
+    override fun withoutAnnotations(): IntElement
+    override fun withMetas(additionalMetas: MetaContainer): IntElement
+    override fun withMeta(key: String, value: Any): IntElement
+    override fun withoutMetas(): IntElement
 }
 
 /** Represents a Ion decimal. */
 interface DecimalElement : IonElement {
     val decimalValue: Decimal
     override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): DecimalElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): DecimalElement
+    override fun withoutAnnotations(): DecimalElement
+    override fun withMetas(additionalMetas: MetaContainer): DecimalElement
+    override fun withMeta(key: String, value: Any): DecimalElement
+    override fun withoutMetas(): DecimalElement
 }
 
 /**
@@ -150,12 +202,26 @@ interface DecimalElement : IonElement {
 interface FloatElement : IonElement {
     val doubleValue: Double
     override fun copy(annotations: List<String>, metas: MetaContainer): FloatElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): FloatElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): FloatElement
+    override fun withoutAnnotations(): FloatElement
+    override fun withMetas(additionalMetas: MetaContainer): FloatElement
+    override fun withMeta(key: String, value: Any): FloatElement
+    override fun withoutMetas(): FloatElement
 }
 
 /** Represents an Ion string or symbol. */
 interface TextElement : IonElement {
     val textValue: String
     override fun copy(annotations: List<String>, metas: MetaContainer): TextElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): TextElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): TextElement
+    override fun withoutAnnotations(): TextElement
+    override fun withMetas(additionalMetas: MetaContainer): TextElement
+    override fun withMeta(key: String, value: Any): TextElement
+    override fun withoutMetas(): TextElement
 }
 
 /**
@@ -166,6 +232,13 @@ interface TextElement : IonElement {
  */
 interface StringElement : TextElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): StringElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): StringElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StringElement
+    override fun withoutAnnotations(): StringElement
+    override fun withMetas(additionalMetas: MetaContainer): StringElement
+    override fun withMeta(key: String, value: Any): StringElement
+    override fun withoutMetas(): StringElement
 }
 
 /**
@@ -176,12 +249,26 @@ interface StringElement : TextElement {
  */
 interface SymbolElement : TextElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SymbolElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SymbolElement
+    override fun withoutAnnotations(): SymbolElement
+    override fun withMetas(additionalMetas: MetaContainer): SymbolElement
+    override fun withMeta(key: String, value: Any): SymbolElement
+    override fun withoutMetas(): SymbolElement
 }
 
 /** Represents an Ion clob or blob. */
 interface LobElement : IonElement {
     val bytesValue:  ByteArrayView
     override fun copy(annotations: List<String>, metas: MetaContainer): LobElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): LobElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): LobElement
+    override fun withoutAnnotations(): LobElement
+    override fun withMetas(additionalMetas: MetaContainer): LobElement
+    override fun withMeta(key: String, value: Any): LobElement
+    override fun withoutMetas(): LobElement
 }
 
 /**
@@ -192,6 +279,13 @@ interface LobElement : IonElement {
  */
 interface BlobElement : LobElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): BlobElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): BlobElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BlobElement
+    override fun withoutAnnotations(): BlobElement
+    override fun withMetas(additionalMetas: MetaContainer): BlobElement
+    override fun withMeta(key: String, value: Any): BlobElement
+    override fun withoutMetas(): BlobElement
 }
 
 /**
@@ -202,6 +296,13 @@ interface BlobElement : LobElement {
  */
 interface ClobElement : LobElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): ClobElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ClobElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ClobElement
+    override fun withoutAnnotations(): ClobElement
+    override fun withMetas(additionalMetas: MetaContainer): ClobElement
+    override fun withMeta(key: String, value: Any): ClobElement
+    override fun withoutMetas(): ClobElement
 }
 
 /**
@@ -223,6 +324,13 @@ interface ContainerElement : IonElement {
     val values: Collection<AnyElement>
 
     override fun copy(annotations: List<String>, metas: MetaContainer): ContainerElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ContainerElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ContainerElement
+    override fun withoutAnnotations(): ContainerElement
+    override fun withMetas(additionalMetas: MetaContainer): ContainerElement
+    override fun withMeta(key: String, value: Any): ContainerElement
+    override fun withoutMetas(): ContainerElement
 }
 
 /**
@@ -238,10 +346,17 @@ interface ContainerElement : IonElement {
  * @see [IonElement]
  */
 interface SeqElement : ContainerElement {
-    override fun copy(annotations: List<String>, metas: MetaContainer): SeqElement
-
     /** Narrows the return type of [ContainerElement.values] to [List<AnyElement>]. */
     override val values: List<AnyElement>
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): SeqElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SeqElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SeqElement
+    override fun withoutAnnotations(): SeqElement
+    override fun withMetas(additionalMetas: MetaContainer): SeqElement
+    override fun withMeta(key: String, value: Any): SeqElement
+    override fun withoutMetas(): SeqElement
 }
 /**
  * Represents an Ion list.
@@ -257,6 +372,13 @@ interface SeqElement : ContainerElement {
  */
 interface ListElement : SeqElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): ListElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ListElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ListElement
+    override fun withoutAnnotations(): ListElement
+    override fun withMetas(additionalMetas: MetaContainer): ListElement
+    override fun withMeta(key: String, value: Any): ListElement
+    override fun withoutMetas(): ListElement
 }
 
 /**
@@ -273,6 +395,13 @@ interface ListElement : SeqElement {
  */
 interface SexpElement : SeqElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): SexpElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SexpElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SexpElement
+    override fun withoutAnnotations(): SexpElement
+    override fun withMetas(additionalMetas: MetaContainer): SexpElement
+    override fun withMeta(key: String, value: Any): SexpElement
+    override fun withoutMetas(): SexpElement
 }
 
 /**
@@ -311,4 +440,10 @@ interface StructElement : ContainerElement {
     fun containsField(fieldName: String): Boolean
 
     override fun copy(annotations: List<String>, metas: MetaContainer): StructElement
+    override fun withAnnotations(vararg additionalAnnotations: String): StructElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StructElement
+    override fun withoutAnnotations(): StructElement
+    override fun withMetas(additionalMetas: MetaContainer): StructElement
+    override fun withMeta(key: String, value: Any): StructElement
+    override fun withoutMetas(): StructElement
 }

--- a/src/com/amazon/ionelement/api/IonElementExtensions.kt
+++ b/src/com/amazon/ionelement/api/IonElementExtensions.kt
@@ -16,7 +16,7 @@
 package com.amazon.ionelement.api
 
 /** Returns a shallow copy of the current node with the specified additional annotations. */
-inline fun <reified T: IonElement> T.withAnnotations(vararg additionalAnnotations: String): T =
+internal inline fun <reified T: IonElement> T._withAnnotations(vararg additionalAnnotations: String): T =
     when {
         additionalAnnotations.isEmpty() -> this
         else -> copy(annotations = this.annotations + additionalAnnotations) as T
@@ -24,11 +24,11 @@ inline fun <reified T: IonElement> T.withAnnotations(vararg additionalAnnotation
 
 
 /** Returns a shallow copy of the current node with the specified additional annotations. */
-inline fun <reified T: IonElement> T.withAnnotations(additionalAnnotations: Iterable<String>): T =
-    withAnnotations(*additionalAnnotations.toList().toTypedArray())
+internal inline fun <reified T: IonElement> T._withAnnotations(additionalAnnotations: Iterable<String>): T =
+    _withAnnotations(*additionalAnnotations.toList().toTypedArray())
 
 /** Returns a shallow copy of the current node with all annotations removed. */
-inline fun <reified T: IonElement> T.withoutAnnotations(): T =
+internal inline fun <reified T: IonElement> T._withoutAnnotations(): T =
     when {
         this.annotations.isNotEmpty() -> copy(annotations = emptyList()) as T
         else -> this
@@ -38,7 +38,7 @@ inline fun <reified T: IonElement> T.withoutAnnotations(): T =
  * Returns a shallow copy of the current node with the specified additional metadata, overwriting any metas
  * that already exist with the same keys.
  */
-inline fun <reified T: IonElement> T.withMetas(additionalMetas: MetaContainer): T =
+internal inline fun <reified T: IonElement> T._withMetas(additionalMetas: MetaContainer): T =
     when {
         additionalMetas.isEmpty() -> this
         else -> copy(metas = metaContainerOf(metas.toList().union(additionalMetas.toList()).toList())) as T
@@ -50,11 +50,11 @@ inline fun <reified T: IonElement> T.withMetas(additionalMetas: MetaContainer): 
  *
  * When adding multiple metas, consider [withMetas] instead.
  */
-inline fun <reified T: IonElement> T.withMeta(key: String, value: Any): T =
-    withMetas(metaContainerOf(key to value))
+internal inline fun <reified T: IonElement> T._withMeta(key: String, value: Any): T =
+    _withMetas(metaContainerOf(key to value))
 
 /** Returns a shallow copy of the current node without any metadata. */
-inline fun <reified T: IonElement> T.withoutMetas(): T =
+internal inline fun <reified T: IonElement> T._withoutMetas(): T =
     when {
         metas.isEmpty() -> this
         else -> copy(metas = emptyMetaContainer(), annotations = annotations) as T

--- a/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
@@ -17,13 +17,9 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ion.IntegerSize
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.IntElement
-import com.amazon.ionelement.api.IntElementSize
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.constraintError
-import com.amazon.ionelement.api.emptyMetaContainer
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -46,8 +42,15 @@ internal class BigIntIntElementImpl(
         return bigIntegerValue.longValueExact()
     }
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): IntElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): BigIntIntElementImpl =
         BigIntIntElementImpl(bigIntegerValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): BigIntIntElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BigIntIntElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): BigIntIntElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): BigIntIntElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): BigIntIntElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): BigIntIntElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeInt(bigIntegerValue)
 

--- a/src/com/amazon/ionelement/impl/BlobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BlobElementImpl.kt
@@ -16,12 +16,9 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.BlobElement
-import com.amazon.ionelement.api.ByteArrayView
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
-
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
+
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -36,8 +33,15 @@ internal class BlobElementImpl(
 
     override fun writeContentTo(writer: IonWriter) = writer.writeBlob(bytes)
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): BlobElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): BlobElementImpl =
         BlobElementImpl(bytes, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): BlobElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BlobElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): BlobElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): BlobElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): BlobElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): BlobElementImpl = _withoutMetas()
 
     override val type: ElementType get() = ElementType.BLOB
 }

--- a/src/com/amazon/ionelement/impl/BoolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BoolElementImpl.kt
@@ -16,11 +16,8 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.BoolElement
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -32,9 +29,16 @@ internal class BoolElementImpl(
 ): AnyElementBase(), BoolElement {
     override val type: ElementType get() = ElementType.BOOL
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): BoolElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): BoolElementImpl =
         BoolElementImpl(booleanValue, annotations.toPersistentList(), metas.toPersistentMap())
 
+    override fun withAnnotations(vararg additionalAnnotations: String): BoolElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BoolElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): BoolElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): BoolElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): BoolElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): BoolElementImpl = _withoutMetas()
+    
     override fun writeContentTo(writer: IonWriter) = writer.writeBool(booleanValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/com/amazon/ionelement/impl/ClobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ClobElementImpl.kt
@@ -16,13 +16,9 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.ByteArrayView
-import com.amazon.ionelement.api.ClobElement
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
-
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
+
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -36,8 +32,15 @@ internal class ClobElementImpl(
     override val clobValue: ByteArrayView get() = bytesValue
 
     override fun writeContentTo(writer: IonWriter) = writer.writeClob(bytes)
-    override fun copy(annotations: List<String>, metas: MetaContainer): ClobElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): ClobElementImpl =
         ClobElementImpl(bytes, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ClobElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ClobElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): ClobElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): ClobElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): ClobElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): ClobElementImpl = _withoutMetas()
 
     override val type: ElementType get() = ElementType.CLOB
 }

--- a/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
@@ -17,12 +17,9 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ion.Decimal
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.DecimalElement
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
-
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
+
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -34,8 +31,15 @@ internal class DecimalElementImpl(
 ) : AnyElementBase(), DecimalElement {
     override val type get() = ElementType.DECIMAL
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElementImpl =
         DecimalElementImpl(decimalValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): DecimalElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): DecimalElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): DecimalElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): DecimalElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): DecimalElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): DecimalElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeDecimal(decimalValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/FloatElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/FloatElementImpl.kt
@@ -16,12 +16,9 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.FloatElement
-import com.amazon.ionelement.api.MetaContainer
-
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
+
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -33,8 +30,15 @@ internal class FloatElementImpl(
 ) : AnyElementBase(), FloatElement {
     override val type: ElementType get() = ElementType.FLOAT
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): FloatElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): FloatElementImpl =
         FloatElementImpl(doubleValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): FloatElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): FloatElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): FloatElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): FloatElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): FloatElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): FloatElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeFloat(doubleValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -23,34 +23,7 @@ import com.amazon.ion.OffsetSpan
 import com.amazon.ion.SpanProvider
 import com.amazon.ion.TextSpan
 import com.amazon.ion.system.IonReaderBuilder
-import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.ION_LOCATION_META_TAG
-import com.amazon.ionelement.api.IonBinaryLocation
-import com.amazon.ionelement.api.IonElementException
-import com.amazon.ionelement.api.IonElementLoader
-import com.amazon.ionelement.api.IonElementLoaderException
-import com.amazon.ionelement.api.IonElementLoaderOptions
-import com.amazon.ionelement.api.IonLocation
-import com.amazon.ionelement.api.IonTextLocation
-import com.amazon.ionelement.api.StructField
-import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ionelement.api.ionBlob
-import com.amazon.ionelement.api.ionBool
-import com.amazon.ionelement.api.ionClob
-import com.amazon.ionelement.api.ionDecimal
-import com.amazon.ionelement.api.ionFloat
-import com.amazon.ionelement.api.ionInt
-import com.amazon.ionelement.api.ionListOf
-import com.amazon.ionelement.api.ionNull
-import com.amazon.ionelement.api.ionSexpOf
-import com.amazon.ionelement.api.ionString
-import com.amazon.ionelement.api.ionStructOf
-import com.amazon.ionelement.api.ionSymbol
-import com.amazon.ionelement.api.ionTimestamp
-import com.amazon.ionelement.api.metaContainerOf
-import com.amazon.ionelement.api.toElementType
-import com.amazon.ionelement.api.withAnnotations
-import com.amazon.ionelement.api.withMetas
+import com.amazon.ionelement.api.*
 
 class IonElementLoaderImpl(private val options: IonElementLoaderOptions) : IonElementLoader {
 
@@ -193,10 +166,10 @@ class IonElementLoaderImpl(private val options: IonElementLoaderOptions) : IonEl
             }.asAnyElement()
 
             if (annotations.any()) {
-                element = element.withAnnotations(*annotations)
+                element = element._withAnnotations(*annotations)
             }
             if (metas.any()) {
-                element = element.withMetas(metas)
+                element = element._withMetas(metas)
             }
 
             element

--- a/src/com/amazon/ionelement/impl/ListElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ListElementImpl.kt
@@ -15,10 +15,7 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.ListElement
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
@@ -33,8 +30,15 @@ internal class ListElementImpl (
 
     override val listValues: List<AnyElement> get() = values
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): ListElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): ListElementImpl =
         ListElementImpl(values, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ListElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ListElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): ListElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): ListElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): ListElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): ListElementImpl = _withoutMetas()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/com/amazon/ionelement/impl/LobElementBase.kt
+++ b/src/com/amazon/ionelement/impl/LobElementBase.kt
@@ -17,12 +17,21 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ionelement.api.ByteArrayView
 import com.amazon.ionelement.api.LobElement
+import com.amazon.ionelement.api.MetaContainer
 
 internal abstract class LobElementBase(
     protected val bytes: ByteArray
 ): AnyElementBase(), LobElement {
 
     override val bytesValue: ByteArrayView = ByteArrayViewImpl(bytes)
+
+    abstract override fun copy(annotations: List<String>, metas: MetaContainer): LobElementBase
+    abstract override fun withAnnotations(vararg additionalAnnotations: String): LobElementBase
+    abstract override fun withAnnotations(additionalAnnotations: Iterable<String>): LobElementBase
+    abstract override fun withoutAnnotations(): LobElementBase
+    abstract override fun withMetas(additionalMetas: MetaContainer): LobElementBase
+    abstract override fun withMeta(key: String, value: Any): LobElementBase
+    abstract override fun withoutMetas(): LobElementBase
 
     override fun equals(other: Any?): Boolean {
         return when {

--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -16,10 +16,7 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.IntElement
-import com.amazon.ionelement.api.IntElementSize
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
@@ -36,8 +33,15 @@ internal class LongIntElementImpl(
 
     override val bigIntegerValue: BigInteger get() = BigInteger.valueOf(longValue)
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): IntElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): LongIntElementImpl =
         LongIntElementImpl(longValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): LongIntElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): LongIntElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): LongIntElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): LongIntElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): LongIntElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): LongIntElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeInt(longValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/NullElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/NullElementImpl.kt
@@ -16,11 +16,8 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.emptyMetaContainer
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -35,6 +32,13 @@ internal class NullElementImpl(
 
     override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement =
         NullElementImpl(type, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): AnyElement = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): AnyElement = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): AnyElement = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): AnyElement = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): AnyElement = _withMeta(key, value)
+    override fun withoutMetas(): AnyElement = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeNull(type.toIonType())
 

--- a/src/com/amazon/ionelement/impl/SeqElementBase.kt
+++ b/src/com/amazon/ionelement/impl/SeqElementBase.kt
@@ -17,6 +17,7 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.AnyElement
+import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.SeqElement
 import kotlinx.collections.immutable.PersistentList
 
@@ -37,6 +38,14 @@ internal abstract class SeqElementBase(
         }
         writer.stepOut()
     }
+
+    abstract override fun copy(annotations: List<String>, metas: MetaContainer): SeqElementBase
+    abstract override fun withAnnotations(vararg additionalAnnotations: String): SeqElementBase
+    abstract override fun withAnnotations(additionalAnnotations: Iterable<String>): SeqElementBase
+    abstract override fun withoutAnnotations(): SeqElementBase
+    abstract override fun withMetas(additionalMetas: MetaContainer): SeqElementBase
+    abstract override fun withMeta(key: String, value: Any): SeqElementBase
+    abstract override fun withoutMetas(): SeqElementBase
 }
 
 

--- a/src/com/amazon/ionelement/impl/SexpElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SexpElementImpl.kt
@@ -15,11 +15,8 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.SexpElement
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -33,8 +30,15 @@ internal class SexpElementImpl (
 
     override val sexpValues: List<AnyElement> get() = seqValues
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): SexpElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): SexpElementImpl =
         SexpElementImpl(values, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SexpElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SexpElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): SexpElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): SexpElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): SexpElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): SexpElementImpl = _withoutMetas()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/com/amazon/ionelement/impl/StringElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StringElementImpl.kt
@@ -16,10 +16,8 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.StringElement
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -33,8 +31,15 @@ internal class StringElementImpl(
 
     override val stringValue: String get() = textValue
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): StringElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): StringElementImpl =
         StringElementImpl(textValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): StringElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StringElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): StringElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): StringElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): StringElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): StringElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeString(textValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -17,12 +17,8 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonType
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.StructElement
-import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.constraintError
 import kotlinx.collections.immutable.PersistentCollection
 import kotlinx.collections.immutable.PersistentList
@@ -81,8 +77,15 @@ internal class StructElementImpl(
 
     override fun containsField(fieldName: String): Boolean = fieldsByName.containsKey(fieldName)
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): StructElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): StructElementImpl =
         StructElementImpl(allFields, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): StructElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StructElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): StructElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): StructElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): StructElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): StructElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) {
         writer.stepIn(IonType.STRUCT)

--- a/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
@@ -16,11 +16,8 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.SymbolElement
-import com.amazon.ionelement.api.emptyMetaContainer
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -34,8 +31,15 @@ internal class SymbolElementImpl(
 
     override val symbolValue: String get() = textValue
 
-    override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElementImpl =
         SymbolElementImpl(textValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SymbolElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SymbolElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): SymbolElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): SymbolElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): SymbolElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): SymbolElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeSymbol(textValue)
     override fun equals(other: Any?): Boolean {

--- a/src/com/amazon/ionelement/impl/TextElementBase.kt
+++ b/src/com/amazon/ionelement/impl/TextElementBase.kt
@@ -15,7 +15,19 @@
 
 package com.amazon.ionelement.impl
 
+import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.TextElement
+
 internal abstract class TextElementBase(
     override val textValue: String
-): AnyElementBase()
+): AnyElementBase(), TextElement {
+
+    abstract override fun copy(annotations: List<String>, metas: MetaContainer): TextElementBase
+    abstract override fun withAnnotations(vararg additionalAnnotations: String): TextElementBase
+    abstract override fun withAnnotations(additionalAnnotations: Iterable<String>): TextElementBase
+    abstract override fun withoutAnnotations(): TextElementBase
+    abstract override fun withMetas(additionalMetas: MetaContainer): TextElementBase
+    abstract override fun withMeta(key: String, value: Any): TextElementBase
+    abstract override fun withoutMetas(): TextElementBase
+}
 

--- a/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
@@ -17,10 +17,8 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ion.IonWriter
 import com.amazon.ion.Timestamp
-import com.amazon.ionelement.api.ElementType
-import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-import com.amazon.ionelement.api.TimestampElement
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -32,8 +30,15 @@ internal class TimestampElementImpl(
 ): AnyElementBase(), TimestampElement {
 
     override val type: ElementType get() = ElementType.TIMESTAMP
-    override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElement =
+    override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElementImpl =
         TimestampElementImpl(timestampValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): TimestampElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): TimestampElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): TimestampElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): TimestampElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): TimestampElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): TimestampElementImpl = _withoutMetas()
 
     override fun writeContentTo(writer: IonWriter) = writer.writeTimestamp(timestampValue)
 

--- a/test/com/amazon/ionelement/EquivTestCase.kt
+++ b/test/com/amazon/ionelement/EquivTestCase.kt
@@ -19,8 +19,6 @@ import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.createIonElementLoader
 import com.amazon.ionelement.api.ionStructOf
-import com.amazon.ionelement.api.withAnnotations
-import com.amazon.ionelement.api.withMeta
 import org.junit.jupiter.api.Assertions
 
 data class EquivTestCase(val left: String, val right: String, val isEquiv: Boolean) {

--- a/test/com/amazon/ionelement/IonElementExtensionsTests.kt
+++ b/test/com/amazon/ionelement/IonElementExtensionsTests.kt
@@ -1,53 +1,70 @@
 package com.amazon.ionelement
 
-import com.amazon.ionelement.api.IonElement
-import com.amazon.ionelement.api.head
-import com.amazon.ionelement.api.ionInt
-import com.amazon.ionelement.api.loadSingleElement
-import com.amazon.ionelement.api.metaContainerOf
-import com.amazon.ionelement.api.tail
-import com.amazon.ionelement.api.withAnnotations
-import com.amazon.ionelement.api.withMeta
-import com.amazon.ionelement.api.withMetas
-import com.amazon.ionelement.api.withoutAnnotations
-import com.amazon.ionelement.api.withoutMetas
+import com.amazon.ion.Decimal
+import com.amazon.ionelement.api.*
+import com.amazon.ionelement.util.ArgumentsProviderBase
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.jupiter.params.provider.MethodSource
+import java.math.BigDecimal
+import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-class IonElementExtensionsTests {
+class IonElementExtensionsTests: ArgumentsProviderBase() {
 
-    @Test
-    fun withAnnotationsVariadic() {
-        val oneAnno = ionInt(1).withAnnotations("foo")
+    override fun getParameters(): List<IonElement> = listOf(
+        ionInt(1),
+        ionInt(BigInteger("${Long.MAX_VALUE}000")),
+        ionFloat(1.0),
+        ionDecimal(Decimal.valueOf("1.0")),
+        ionString("hello"),
+        ionSymbol("world"),
+        ionBool(true),
+        ionNull(ElementType.BOOL),
+        ionTimestamp("2022-01-01"),
+        emptyIonList(),
+        emptyIonSexp(),
+        emptyIonStruct(),
+        emptyClob(),
+        emptyBlob()
+    )
+
+    @ParameterizedTest
+    @ArgumentsSource(IonElementExtensionsTests::class)
+    fun withAnnotationsVariadic(element: IonElement) {
+        val oneAnno = element.withAnnotations("foo")
         assertSame(oneAnno, oneAnno.withAnnotations())
         assertEquals(1, oneAnno.annotations.size)
         assertTrue(oneAnno.annotations.contains("foo"))
 
-        val twoAnno1 = ionInt(1).withAnnotations("foo", "bar")
+        val twoAnno1 = element.withAnnotations("foo", "bar")
         assertSame(twoAnno1, twoAnno1.withAnnotations())
         assertEquals(2, twoAnno1.annotations.size)
         assertTrue(twoAnno1.annotations.contains("foo"))
         assertTrue(twoAnno1.annotations.contains("bar"))
 
-        val twoAnno2 = ionInt(1).withAnnotations("foo").withAnnotations("bar")
+        val twoAnno2 = element.withAnnotations("foo").withAnnotations("bar")
         assertSame(twoAnno2, twoAnno2.withAnnotations())
         assertEquals(2, twoAnno2.annotations.size)
         assertTrue(twoAnno2.annotations.contains("foo"))
         assertTrue(twoAnno2.annotations.contains("bar"))
     }
 
-    @Test
-    fun withAnnotationsList() {
-        val twoAnno1 = ionInt(1).withAnnotations(listOf("foo", "bar"))
+    @ParameterizedTest
+    @ArgumentsSource(IonElementExtensionsTests::class)
+    fun withAnnotationsList(element: IonElement) {
+        val twoAnno1 = element.withAnnotations(listOf("foo", "bar"))
         assertSame(twoAnno1, twoAnno1.withAnnotations())
         assertEquals(2, twoAnno1.annotations.size)
         assertTrue(twoAnno1.annotations.contains("foo"))
         assertTrue(twoAnno1.annotations.contains("bar"))
 
-        val twoAnno2 = ionInt(1).withAnnotations(listOf("foo")).withAnnotations(listOf("bar"))
+        val twoAnno2 = element.withAnnotations(listOf("foo")).withAnnotations(listOf("bar"))
         assertSame(twoAnno2, twoAnno2.withAnnotations())
         assertEquals(2, twoAnno2.annotations.size)
         assertTrue(twoAnno2.annotations.contains("foo"))
@@ -57,9 +74,10 @@ class IonElementExtensionsTests {
         assertEquals(0, noAnnos.annotations.size)
     }
 
-    @Test
-    fun withoutAnnotations() {
-        val hasAnnos = loadSingleElement("foo::bar::1").withMeta("foo", 42).asInt()
+    @ParameterizedTest
+    @ArgumentsSource(IonElementExtensionsTests::class)
+    fun withoutAnnotations(element: IonElement) {
+        val hasAnnos = element.withAnnotations("foo", "bar").withMeta("foo", 42)
         assertEquals(2, hasAnnos.annotations.size)
 
         val noAnnos = hasAnnos.withoutAnnotations()
@@ -69,17 +87,18 @@ class IonElementExtensionsTests {
         assertEquals(42, noAnnos.metas["foo"])
     }
 
-    @Test
-    fun metas() {
-        val oneMeta = ionInt(1).withMeta("foo", 42)
+    @ParameterizedTest
+    @ArgumentsSource(IonElementExtensionsTests::class)
+    fun metas(element: IonElement) {
+        val oneMeta = element.withMeta("foo", 42)
         assertEquals(1, oneMeta.metas.size)
         assertEquals(42, oneMeta.metas["foo"])
 
-        val twoMeta1 = ionInt(1).withMeta("foo", 42).withMeta("bar", 43)
+        val twoMeta1 = element.withMeta("foo", 42).withMeta("bar", 43)
         assertEquals(42, twoMeta1.metas["foo"])
         assertEquals(43, twoMeta1.metas["bar"])
 
-        val twoMeta2 = ionInt(1).withMetas(metaContainerOf("foo" to 52, "bar" to 53))
+        val twoMeta2 = element.withMetas(metaContainerOf("foo" to 52, "bar" to 53))
         assertEquals(52, twoMeta2.metas["foo"])
         assertEquals(53, twoMeta2.metas["bar"])
 
@@ -97,9 +116,10 @@ class IonElementExtensionsTests {
         assertEquals(0, noMetas.annotations.size)
     }
 
-    @Test
-    fun withoutMetas() {
-        val hasMetas = loadSingleElement("foo::1").withMeta("foo", 42)
+    @ParameterizedTest
+    @ArgumentsSource(IonElementExtensionsTests::class)
+    fun withoutMetas(element: IonElement) {
+        val hasMetas = element.withAnnotations("foo").withMeta("foo", 42)
         assertEquals(1, hasMetas.annotations.size)
         assertTrue(hasMetas.annotations.contains("foo"))
 

--- a/test/com/amazon/ionelement/IonElementLoaderTests.kt
+++ b/test/com/amazon/ionelement/IonElementLoaderTests.kt
@@ -25,7 +25,6 @@ import com.amazon.ionelement.api.ionTimestamp
 import com.amazon.ionelement.api.loadSingleElement
 import com.amazon.ionelement.api.toIonElement
 import com.amazon.ionelement.api.toIonValue
-import com.amazon.ionelement.api.withAnnotations
 import com.amazon.ionelement.util.ION
 import com.amazon.ionelement.util.INCLUDE_LOCATION_META
 import com.amazon.ionelement.util.IonElementLoaderTestCase

--- a/test/com/amazon/ionelement/util/randomElement.kt
+++ b/test/com/amazon/ionelement/util/randomElement.kt
@@ -30,7 +30,6 @@ import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.ionStructOf
 import com.amazon.ionelement.api.ionSymbol
 import com.amazon.ionelement.api.ionTimestamp
-import com.amazon.ionelement.api.withAnnotations
 import java.util.Random
 
 val randomSeed = Random().nextLong()


### PR DESCRIPTION
**Issue #, if available:**

Fixes #53 

**Description of changes:**

Adds the `with*` mutators to the `IonElement` interface, and covariant return types to all sub-interfaces and concrete implementations.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

