### PR TITLE
Upgrade Kotlin compiler version to 1.6.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 
 plugins {
     id 'java-library'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id 'org.jetbrains.kotlin.jvm' version '1.6.20'
     id 'maven-publish'
     id 'signing'
     id 'org.jetbrains.dokka' version '0.9.18'
@@ -38,6 +38,8 @@ repositories {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "1.8"
+        apiVersion = "1.3"
+        languageVersion = "1.4" // Can be read by 1.3 compiler, so consumers on kotlin 1.3 are still supported.
     }
 }
 


### PR DESCRIPTION

**Issue #, if available:**

Fixes #46 

**Description of changes:**

Updates the project to use the v1.6.20 Kotlin compiler, but sets options to preserve compatibility with Kotlin 1.3 (the version of Kotlin that we were previously using).

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

