### PR TITLE
Enables explicit API mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     }
 }
 
+kotlin {
+    explicitApi = 'strict'
+}
+
 dependencies {
     api 'com.amazon.ion:ion-java:[1.4.0,)'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'

--- a/src/com/amazon/ionelement/api/AnyElement.kt
+++ b/src/com/amazon/ionelement/api/AnyElement.kt
@@ -147,210 +147,210 @@ import java.math.BigInteger
  *
  * @see [IonElement]
  */
-interface AnyElement : IonElement {
+public interface AnyElement : IonElement {
 
     /** See [AnyElement]. */
-    fun asBoolean(): BoolElement
+    public fun asBoolean(): BoolElement
 
     /** See [AnyElement]. */
-    fun asBooleanOrNull(): BoolElement?
+    public fun asBooleanOrNull(): BoolElement?
 
     /** See [AnyElement]. */
-    fun asInt(): IntElement
+    public fun asInt(): IntElement
 
     /** See [AnyElement]. */
-    fun asIntOrNull(): IntElement?
+    public fun asIntOrNull(): IntElement?
 
     /** See [AnyElement]. */
-    fun asDecimal(): DecimalElement
+    public fun asDecimal(): DecimalElement
 
     /** See [AnyElement]. */
-    fun asDecimalOrNull(): DecimalElement?
+    public fun asDecimalOrNull(): DecimalElement?
 
     /** See [AnyElement]. */
-    fun asFloat(): FloatElement
+    public fun asFloat(): FloatElement
 
     /** See [AnyElement]. */
-    fun asFloatOrNull(): FloatElement?
+    public fun asFloatOrNull(): FloatElement?
 
     /** See [AnyElement]. */
-    fun asText(): TextElement
+    public fun asText(): TextElement
 
     /** See [AnyElement]. */
-    fun asTextOrNull(): TextElement?
+    public fun asTextOrNull(): TextElement?
 
     /** See [AnyElement]. */
-    fun asString(): StringElement
+    public fun asString(): StringElement
 
     /** See [AnyElement]. */
-    fun asStringOrNull(): StringElement?
+    public fun asStringOrNull(): StringElement?
 
     /** See [AnyElement]. */
-    fun asSymbol(): SymbolElement
+    public fun asSymbol(): SymbolElement
 
     /** See [AnyElement]. */
-    fun asSymbolOrNull(): SymbolElement?
+    public fun asSymbolOrNull(): SymbolElement?
 
     /** See [AnyElement]. */
-    fun asTimestamp(): TimestampElement
+    public fun asTimestamp(): TimestampElement
 
     /** See [AnyElement]. */
-    fun asTimestampOrNull(): TimestampElement?
+    public fun asTimestampOrNull(): TimestampElement?
 
     /** See [AnyElement]. */
-    fun asLob(): LobElement
+    public fun asLob(): LobElement
 
     /** See [AnyElement]. */
-    fun asLobOrNull(): LobElement?
+    public fun asLobOrNull(): LobElement?
 
     /** See [AnyElement]. */
-    fun asBlob(): BlobElement
+    public fun asBlob(): BlobElement
 
     /** See [AnyElement]. */
-    fun asBlobOrNull(): BlobElement?
+    public fun asBlobOrNull(): BlobElement?
 
     /** See [AnyElement]. */
-    fun asClob(): ClobElement
+    public fun asClob(): ClobElement
 
     /** See [AnyElement]. */
-    fun asClobOrNull(): ClobElement?
+    public fun asClobOrNull(): ClobElement?
 
     /** See [AnyElement]. */
-    fun asContainer(): ContainerElement
+    public fun asContainer(): ContainerElement
 
     /** See [AnyElement]. */
-    fun asContainerOrNull(): ContainerElement?
+    public fun asContainerOrNull(): ContainerElement?
 
     /** See [AnyElement]. */
-    fun asSeq(): SeqElement
+    public fun asSeq(): SeqElement
 
     /** See [AnyElement]. */
-    fun asSeqOrNull(): SeqElement?
+    public fun asSeqOrNull(): SeqElement?
 
     /** See [AnyElement]. */
-    fun asList(): ListElement
+    public fun asList(): ListElement
 
     /** See [AnyElement]. */
-    fun asListOrNull(): ListElement?
+    public fun asListOrNull(): ListElement?
 
     /** See [AnyElement]. */
-    fun asSexp(): SexpElement
+    public fun asSexp(): SexpElement
 
     /** See [AnyElement]. */
-    fun asSexpOrNull(): SexpElement?
+    public fun asSexpOrNull(): SexpElement?
 
     /** See [AnyElement]. */
-    fun asStruct(): StructElement
+    public fun asStruct(): StructElement
 
     /** See [AnyElement]. */
-    fun asStructOrNull(): StructElement?
+    public fun asStructOrNull(): StructElement?
 
     /**
      * If this is an Ion integer, returns its [IntElementSize] otherwise, throws [IonElementConstraintException].
      */
-    val integerSize: IntElementSize
+    public val integerSize: IntElementSize
 
     /** See [AnyElement]. */
-    val booleanValue: Boolean
+    public val booleanValue: Boolean
 
     /** See [AnyElement]. */
-    val booleanValueOrNull: Boolean?
+    public val booleanValueOrNull: Boolean?
 
     /** See [AnyElement]. */
-    val longValue: Long
+    public val longValue: Long
 
     /** See [AnyElement]. */
-    val longValueOrNull: Long?
+    public val longValueOrNull: Long?
 
     /** See [AnyElement]. */
-    val bigIntegerValue: BigInteger
+    public val bigIntegerValue: BigInteger
 
     /** See [AnyElement]. */
-    val bigIntegerValueOrNull: BigInteger?
+    public val bigIntegerValueOrNull: BigInteger?
 
     /** See [AnyElement]. */
-    val textValue: String
+    public val textValue: String
 
     /** See [AnyElement]. */
-    val textValueOrNull: String?
+    public val textValueOrNull: String?
 
     /** See [AnyElement]. */
-    val stringValue: String
+    public val stringValue: String
 
     /** See [AnyElement]. */
-    val stringValueOrNull: String?
+    public val stringValueOrNull: String?
 
     /** See [AnyElement]. */
-    val symbolValue: String
+    public val symbolValue: String
 
     /** See [AnyElement]. */
-    val symbolValueOrNull: String?
+    public val symbolValueOrNull: String?
 
     /** See [AnyElement]. */
-    val decimalValue: Decimal
+    public val decimalValue: Decimal
 
     /** See [AnyElement]. */
-    val decimalValueOrNull: Decimal?
+    public val decimalValueOrNull: Decimal?
 
     /** See [AnyElement]. */
-    val doubleValue: Double
+    public val doubleValue: Double
 
     /** See [AnyElement]. */
-    val doubleValueOrNull: Double?
+    public val doubleValueOrNull: Double?
 
     /** See [AnyElement]. */
-    val timestampValue: Timestamp
+    public val timestampValue: Timestamp
 
     /** See [AnyElement]. */
-    val timestampValueOrNull: Timestamp?
+    public val timestampValueOrNull: Timestamp?
 
     /** See [AnyElement]. */
-    val bytesValue: ByteArrayView
+    public val bytesValue: ByteArrayView
 
     /** See [AnyElement]. */
-    val bytesValueOrNull: ByteArrayView?
+    public val bytesValueOrNull: ByteArrayView?
 
     /** See [AnyElement]. */
-    val blobValue: ByteArrayView
+    public val blobValue: ByteArrayView
 
     /** See [AnyElement]. */
-    val blobValueOrNull: ByteArrayView?
+    public val blobValueOrNull: ByteArrayView?
 
     /** See [AnyElement]. */
-    val clobValue: ByteArrayView
+    public val clobValue: ByteArrayView
 
     /** See [AnyElement]. */
-    val clobValueOrNull: ByteArrayView?
+    public val clobValueOrNull: ByteArrayView?
 
     /** See [AnyElement]. */
-    val containerValues: Collection<AnyElement>
+    public val containerValues: Collection<AnyElement>
 
     /** See [AnyElement]. */
-    val containerValuesOrNull: Collection<AnyElement>?
+    public val containerValuesOrNull: Collection<AnyElement>?
 
     /** See [AnyElement]. */
-    val seqValues: List<AnyElement>
+    public val seqValues: List<AnyElement>
 
     /** See [AnyElement]. */
-    val seqValuesOrNull: List<AnyElement>?
+    public val seqValuesOrNull: List<AnyElement>?
 
     /** See [AnyElement]. */
-    val listValues: List<AnyElement>
+    public val listValues: List<AnyElement>
 
     /** See [AnyElement]. */
-    val listValuesOrNull: List<AnyElement>?
+    public val listValuesOrNull: List<AnyElement>?
 
     /** See [AnyElement]. */
-    val sexpValues: List<AnyElement>
+    public val sexpValues: List<AnyElement>
 
     /** See [AnyElement]. */
-    val sexpValuesOrNull: List<AnyElement>?
+    public val sexpValuesOrNull: List<AnyElement>?
 
     /** See [AnyElement]. */
-    val structFields: Collection<StructField>
+    public val structFields: Collection<StructField>
 
     /** See [AnyElement]. */
-    val structFieldsOrNull: Collection<StructField>?
+    public val structFieldsOrNull: Collection<StructField>?
 
     override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement
     override fun withAnnotations(vararg additionalAnnotations: String): AnyElement

--- a/src/com/amazon/ionelement/api/ByteArrayView.kt
+++ b/src/com/amazon/ionelement/api/ByteArrayView.kt
@@ -16,10 +16,10 @@
 package com.amazon.ionelement.api
 
 /** An immutable wrapper over a [byte[]]. */
-interface ByteArrayView : Iterable<Byte> {
-    fun size(): Int
-    operator fun get(index: Int): Byte
+public interface ByteArrayView : Iterable<Byte> {
+    public fun size(): Int
+    public operator fun get(index: Int): Byte
 
-    fun copyOfBytes(): ByteArray
+    public fun copyOfBytes(): ByteArray
 }
 

--- a/src/com/amazon/ionelement/api/ElementType.kt
+++ b/src/com/amazon/ionelement/api/ElementType.kt
@@ -16,26 +16,26 @@ import com.amazon.ionelement.api.ElementType.SYMBOL
  * has no notion of datagrams.  It also exposes [isText], [isContainer] and [isLob] as properties instead of as static
  * functions.
  */
-enum class ElementType(
+public enum class ElementType(
     /** True if the current [ElementType] is [STRING] or [SYMBOL]. */
-    val isText: Boolean,
+    public val isText: Boolean,
 
     /**
      * True if the current [ElementType] is [LIST] or [SEXP] or [STRUCT].
      *
      * Ordering of the child elements cannot be guaranteed for [STRUCT] elements.
      */
-    val isContainer: Boolean,
+    public val isContainer: Boolean,
 
     /**
      * True if the current [ElementType] is [LIST] or [SEXP].
      *
      * Ordering of the child elements is guaranteed.
      */
-    val isSeq: Boolean,
+    public val isSeq: Boolean,
 
     /** True if the current [ElementType] is [CLOB] or [BLOB]. */
-    val isLob: Boolean
+    public val isLob: Boolean
 ) {
     // Other scalar types
     NULL(false, false, false, false),
@@ -60,7 +60,7 @@ enum class ElementType(
     STRUCT(false, true, false, false);
 
     /** Converts this [ElementType] to [IonType]. */
-    fun toIonType() = when(this) {
+    public fun toIonType(): IonType = when(this) {
         NULL -> IonType.NULL
         BOOL -> IonType.BOOL
         INT -> IonType.INT
@@ -83,7 +83,7 @@ enum class ElementType(
  * @throws [IllegalStateException] if the receiver is [IonType.DATAGRAM] because [AnyElement] has no notion of
  * datagrams.
  */
-fun IonType.toElementType() = when(this) {
+public fun IonType.toElementType(): ElementType = when(this) {
     IonType.NULL -> ElementType.NULL
     IonType.BOOL -> ElementType.BOOL
     IonType.INT -> ElementType.INT

--- a/src/com/amazon/ionelement/api/Ion.kt
+++ b/src/com/amazon/ionelement/api/Ion.kt
@@ -40,7 +40,7 @@ import java.math.BigInteger
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
-typealias Annotations = List<String>
+internal typealias Annotations = List<String>
 
 /*
 
@@ -67,7 +67,7 @@ For example, the following definition:
 
 ```
 @JvmOverloads
-fun ionInt(l: Long, annotations: Annotations = emptyList(), metas: MetaContainer = emptyMetaContainer()): IntElement = ...
+public fun ionInt(l: Long, annotations: Annotations = emptyList(), metas: MetaContainer = emptyMetaContainer()): IntElement = ...
 ```
 
 Synthesizes the following overloads:
@@ -93,7 +93,7 @@ Below, we use a combination of @JvmOverloads and the manually implemented overlo
  * Creates an [IonElement] that represents an Ion `null.null` or a typed `null` with the specified metas
  * and annotations. */
 @JvmOverloads
-fun ionNull(
+public fun ionNull(
     elementType: ElementType = ElementType.NULL,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -113,7 +113,7 @@ fun ionNull(
 /**
  * Creates an [IonElement] that represents an Ion `null.null` or a typed `null` with the specified metas
  * and annotations. */
-fun ionNull(
+public fun ionNull(
     elementType: ElementType = ElementType.NULL,
     metas: MetaContainer
 ): IonElement = ionNull(elementType, emptyList(), metas)
@@ -121,7 +121,7 @@ fun ionNull(
 
 /** Creates a [StringElement] that represents an Ion `symbol`. */
 @JvmOverloads
-fun ionString(
+public fun ionString(
     s: String,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -131,14 +131,14 @@ fun ionString(
     metas = metas.toPersistentMap()
 )
 /** Creates a [StringElement] that represents an Ion `symbol`. */
-fun ionString(
+public fun ionString(
     s: String,
     metas: MetaContainer
 ): StringElement = ionString(s, emptyList(), metas)
 
 /** Creates a [SymbolElement] that represents an Ion `symbol`. */
 @JvmOverloads
-fun ionSymbol(
+public fun ionSymbol(
     s: String,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -149,14 +149,14 @@ fun ionSymbol(
 )
 
 /** Creates a [SymbolElement] that represents an Ion `symbol`. */
-fun ionSymbol(
+public fun ionSymbol(
     s: String,
     metas: MetaContainer
 ): SymbolElement = ionSymbol(s, emptyList(), metas)
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
 @JvmOverloads
-fun ionTimestamp(
+public fun ionTimestamp(
     s: String,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -167,14 +167,14 @@ fun ionTimestamp(
 )
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
-fun ionTimestamp(
+public fun ionTimestamp(
     s: String,
     metas: MetaContainer
 ): TimestampElement = ionTimestamp(s, emptyList(), metas)
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
 @JvmOverloads
-fun ionTimestamp(
+public fun ionTimestamp(
     timestamp: Timestamp,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -185,14 +185,14 @@ fun ionTimestamp(
 )
 
 /** Creates a [TimestampElement] that represents an Ion `timestamp`. */
-fun ionTimestamp(
+public fun ionTimestamp(
     timestamp: Timestamp,
     metas: MetaContainer
 ): TimestampElement = ionTimestamp(timestamp, emptyList(), metas)
 
 /** Creates an [IntElement] that represents an Ion `int`. */
 @JvmOverloads
-fun ionInt(
+public fun ionInt(
     l: Long,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -204,14 +204,14 @@ fun ionInt(
     )
 
 /** Creates an [IntElement] that represents an Ion `int`. */
-fun ionInt(
+public fun ionInt(
     l: Long,
     metas: MetaContainer
 ): IntElement = ionInt(l, emptyList(), metas)
 
 /** Creates an [IntElement] that represents an Ion `BitInteger`. */
 @JvmOverloads
-fun ionInt(
+public fun ionInt(
     bigInt: BigInteger,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -222,14 +222,14 @@ fun ionInt(
 )
 
 /** Creates an [IntElement] that represents an Ion `BitInteger`. */
-fun ionInt(
+public fun ionInt(
     bigInt: BigInteger,
     metas: MetaContainer
 ): IntElement = ionInt(bigInt, emptyList(), metas)
 
 /** Creates a [BoolElement] that represents an Ion `bool`. */
 @JvmOverloads
-fun ionBool(
+public fun ionBool(
     b: Boolean,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -240,14 +240,14 @@ fun ionBool(
 )
 
 /** Creates a [BoolElement] that represents an Ion `bool`. */
-fun ionBool(
+public fun ionBool(
     b: Boolean,
     metas: MetaContainer
 ): BoolElement = ionBool(b, emptyList(), metas)
 
 /** Creates a [FloatElement] that represents an Ion `float`. */
 @JvmOverloads
-fun ionFloat(
+public fun ionFloat(
     d: Double,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -258,14 +258,14 @@ fun ionFloat(
 )
 
 /** Creates a [FloatElement] that represents an Ion `float`. */
-fun ionFloat(
+public fun ionFloat(
     d: Double,
     metas: MetaContainer
 ): FloatElement = ionFloat(d, emptyList(), metas)
 
 /** Creates a [DecimalElement] that represents an Ion `decimall`. */
 @JvmOverloads
-fun ionDecimal(
+public fun ionDecimal(
     bigDecimal: Decimal,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -276,7 +276,7 @@ fun ionDecimal(
 )
 
 /** Creates a [DecimalElement] that represents an Ion `decimall`. */
-fun ionDecimal(
+public fun ionDecimal(
     bigDecimal: Decimal,
     metas: MetaContainer
 ): DecimalElement = ionDecimal(bigDecimal, emptyList(), metas)
@@ -287,7 +287,7 @@ fun ionDecimal(
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
 @JvmOverloads
-fun ionBlob(
+public fun ionBlob(
     bytes: ByteArray,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -302,13 +302,13 @@ fun ionBlob(
  *
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
-fun ionBlob(
+public fun ionBlob(
     bytes: ByteArray,
     metas: MetaContainer
 ): BlobElement = ionBlob(bytes, emptyList(), metas)
 
 /** Returns the empty [BlobElement] singleton. */
-fun emptyBlob(): BlobElement = EMPTY_BLOB
+public fun emptyBlob(): BlobElement = EMPTY_BLOB
 
 /**
  * Creates a [ClobElement] that represents an Ion `clob`.
@@ -316,7 +316,7 @@ fun emptyBlob(): BlobElement = EMPTY_BLOB
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
 @JvmOverloads
-fun ionClob(
+public fun ionClob(
     bytes: ByteArray,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -330,17 +330,17 @@ fun ionClob(
  *
  * Note that the [ByteArray] is cloned so immutability can be enforced.
  */
-fun ionClob(
+public fun ionClob(
     bytes: ByteArray,
     metas: MetaContainer = emptyMetaContainer()
 ): ClobElement = ionClob(bytes, emptyList(), metas)
 
 /** Returns the empty [ClobElement] singleton. */
-fun emptyClob(): ClobElement = EMPTY_CLOB
+public fun emptyClob(): ClobElement = EMPTY_CLOB
 
 /** Creates a [ListElement] that represents an Ion `list`. */
 @JvmOverloads
-fun ionListOf(
+public fun ionListOf(
     iterable: Iterable<IonElement>,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -352,7 +352,7 @@ fun ionListOf(
     )
 
 /** Creates a [ListElement] that represents an Ion `list`. */
-fun ionListOf(
+public fun ionListOf(
     iterable: Iterable<IonElement>,
     metas: MetaContainer
 ): ListElement = ionListOf(iterable, emptyList(), metas)
@@ -363,7 +363,7 @@ fun ionListOf(
  * If calling from Java, please use one of the overloads which accepts the child elements in an instance of
  * `Iterable<IonElement>`.
  */
-fun ionListOf(
+public fun ionListOf(
     vararg elements: IonElement,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -375,7 +375,7 @@ fun ionListOf(
     )
 
 /** Creates a [ListElement] that represents an Ion `list`. */
-fun ionListOf(
+public fun ionListOf(
     vararg elements: IonElement
 ): ListElement =
     ionListOf(
@@ -385,11 +385,11 @@ fun ionListOf(
     )
 
 /** Returns a [ListElement] representing an empty Ion `list`. */
-fun emptyIonList(): ListElement = EMPTY_LIST
+public fun emptyIonList(): ListElement = EMPTY_LIST
 
 /** Creates an [SexpElement] that represents an Ion `sexp`. */
 @JvmOverloads
-fun ionSexpOf(
+public fun ionSexpOf(
     iterable: Iterable<IonElement>,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -401,14 +401,14 @@ fun ionSexpOf(
     )
 
 /** Creates an [SexpElement] that represents an Ion `sexp`. */
-fun ionSexpOf(
+public fun ionSexpOf(
     iterable: Iterable<IonElement>,
     metas: MetaContainer
 ): SexpElement = ionSexpOf(iterable, emptyList(), metas)
 
 /** Creates a [SexpElement] that represents an Ion `sexp`. */
 @JvmOverloads
-fun ionSexpOf(
+public fun ionSexpOf(
     vararg elements: IonElement,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -420,18 +420,18 @@ fun ionSexpOf(
     )
 
 /** Returns a [SexpElement] representing an empty Ion `sexp`. */
-fun emptyIonSexp(): SexpElement = EMPTY_SEXP
+public fun emptyIonSexp(): SexpElement = EMPTY_SEXP
 
 /** Returns a [StructElement] representing an empty Ion `struct`. */
-fun emptyIonStruct(): StructElement = EMPTY_STRUCT
+public fun emptyIonStruct(): StructElement = EMPTY_STRUCT
 
 /** Creates a [StructField] . */
-fun field(key: String, value: IonElement): StructField =
+public fun field(key: String, value: IonElement): StructField =
     StructFieldImpl(name = key, value = value.asAnyElement())
 
 /** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
 @JvmOverloads
-fun ionStructOf(
+public fun ionStructOf(
     fields: Iterable<StructField>,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -443,14 +443,14 @@ fun ionStructOf(
     )
 
 /** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
-fun ionStructOf(
+public fun ionStructOf(
     fields: Iterable<StructField>,
     metas: MetaContainer
 ): StructElement = ionStructOf(fields, emptyList(), metas)
 
 /** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
 @JvmOverloads
-fun ionStructOf(
+public fun ionStructOf(
     vararg fields: StructField,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()
@@ -463,7 +463,7 @@ fun ionStructOf(
 
 /** Creates an [AnyElement] that represents an Ion `struct` with the specified fields. */
 @JvmOverloads
-fun ionStructOf(
+public fun ionStructOf(
     vararg fields: Pair<String, IonElement>,
     annotations: Annotations = emptyList(),
     metas: MetaContainer = emptyMetaContainer()

--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -63,7 +63,7 @@ import java.math.BigInteger
  *
  * When in doubt, prefer use of [Object.equals] and [Object.hashCode] on the [IonElement] instance.
  */
-interface IonElement {
+public interface IonElement {
 
     /**
      * All [IonElement] implementations must convertible to [AnyElement].
@@ -72,25 +72,25 @@ interface IonElement {
      * expensive than a cast.  The purpose of this interface function is to be very clear about the requirement
      * that all implementations of [IonElement] are convertible to [AnyElement].
      */
-    fun asAnyElement(): AnyElement
+    public fun asAnyElement(): AnyElement
 
     /** The Ion data type of the current node.  */
-    val type: ElementType
+    public val type: ElementType
 
     /** This [IonElement]'s metadata. */
-    val metas: MetaContainer
+    public val metas: MetaContainer
 
     /** This element's Ion type annotations. */
-    val annotations: List<String>
+    public val annotations: List<String>
 
     /** Returns true if the current value is `null.null` or any typed null. */
-    val isNull: Boolean
+    public val isNull: Boolean
 
     /** Returns a shallow copy of the current node, replacing the annotations and metas with those specified. */
-    fun copy(annotations: List<String> = this.annotations, metas: MetaContainer = this.metas): IonElement
+    public fun copy(annotations: List<String> = this.annotations, metas: MetaContainer = this.metas): IonElement
 
     /** Writes the current Ion element to the specified [IonWriter]. */
-    fun writeTo(writer: IonWriter)
+    public fun writeTo(writer: IonWriter)
 
     /** Converts the current element to Ion text. */
     override fun toString(): String
@@ -102,19 +102,19 @@ interface IonElement {
      */
 
     /** Returns a shallow copy of the current node with the specified additional annotations. */
-    fun withAnnotations(vararg additionalAnnotations: String): IonElement
+    public fun withAnnotations(vararg additionalAnnotations: String): IonElement
 
     /** Returns a shallow copy of the current node with the specified additional annotations. */
-    fun withAnnotations(additionalAnnotations: Iterable<String>): IonElement
+    public fun withAnnotations(additionalAnnotations: Iterable<String>): IonElement
 
     /** Returns a shallow copy of the current node with all annotations removed. */
-    fun withoutAnnotations(): IonElement
+    public fun withoutAnnotations(): IonElement
 
     /**
      * Returns a shallow copy of the current node with the specified additional metadata, overwriting any metas
      * that already exist with the same keys.
      */
-    fun withMetas(additionalMetas: MetaContainer): IonElement
+    public fun withMetas(additionalMetas: MetaContainer): IonElement
 
     /**
      * Returns a shallow copy of the current node with the specified additional meta, overwriting any meta
@@ -122,15 +122,15 @@ interface IonElement {
      *
      * When adding multiple metas, consider [withMetas] instead.
      */
-    fun withMeta(key: String, value: Any): IonElement
+    public fun withMeta(key: String, value: Any): IonElement
 
     /** Returns a shallow copy of the current node without any metadata. */
-    fun withoutMetas(): IonElement
+    public fun withoutMetas(): IonElement
 }
 
 /** Represents a Ion bool. */
-interface BoolElement : IonElement {
-    val booleanValue: Boolean
+public interface BoolElement : IonElement {
+    public val booleanValue: Boolean
     override fun copy(annotations: List<String>, metas: MetaContainer): BoolElement
     override fun withAnnotations(vararg additionalAnnotations: String): BoolElement
     override fun withAnnotations(additionalAnnotations: Iterable<String>): BoolElement
@@ -141,8 +141,8 @@ interface BoolElement : IonElement {
 }
 
 /** Represents a Ion timestamp. */
-interface TimestampElement : IonElement {
-    val timestampValue: Timestamp
+public interface TimestampElement : IonElement {
+    public val timestampValue: Timestamp
     override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): TimestampElement
@@ -155,7 +155,7 @@ interface TimestampElement : IonElement {
 
 
 /** Indicates the size of the integer element. */
-enum class IntElementSize {
+public enum class IntElementSize {
     /** For integer values representable by a [Long]. */
     LONG,
     /** For values larger than [Long.MAX_VALUE] or smaller than [Long.MIN_VALUE]. */
@@ -163,22 +163,22 @@ enum class IntElementSize {
 }
 
 /** Represents a Ion int. */
-interface IntElement : IonElement {
+public interface IntElement : IonElement {
 
     /** The size of this [IntElement]. */
-    val integerSize: IntElementSize
+    public val integerSize: IntElementSize
 
     /**
      * Use this property to access the integer value of this [IntElement] when its value fits in a [Long].
      *
      * @throws IonElementConstraintException if [integerSize] is [IntElementSize.BIG_INTEGER].
      */
-    val longValue: Long
+    public val longValue: Long
 
     /**
      * This property may be used to access the integer value of this [IntElement] if its value does not fit in a [Long].
      */
-    val bigIntegerValue: BigInteger
+    public val bigIntegerValue: BigInteger
     override fun copy(annotations: List<String>, metas: MetaContainer): IntElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): IntElement
@@ -190,8 +190,8 @@ interface IntElement : IonElement {
 }
 
 /** Represents a Ion decimal. */
-interface DecimalElement : IonElement {
-    val decimalValue: Decimal
+public interface DecimalElement : IonElement {
+    public val decimalValue: Decimal
     override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): DecimalElement
@@ -205,8 +205,8 @@ interface DecimalElement : IonElement {
 /**
  * Represents a Ion float.
  */
-interface FloatElement : IonElement {
-    val doubleValue: Double
+public interface FloatElement : IonElement {
+    public val doubleValue: Double
     override fun copy(annotations: List<String>, metas: MetaContainer): FloatElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): FloatElement
@@ -218,8 +218,8 @@ interface FloatElement : IonElement {
 }
 
 /** Represents an Ion string or symbol. */
-interface TextElement : IonElement {
-    val textValue: String
+public interface TextElement : IonElement {
+    public val textValue: String
     override fun copy(annotations: List<String>, metas: MetaContainer): TextElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): TextElement
@@ -236,7 +236,7 @@ interface TextElement : IonElement {
  * Includes no additional functionality over [TextElement], but serves to provide additional type safety when
  * working with elements that must be Ion strings.
  */
-interface StringElement : TextElement {
+public interface StringElement : TextElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): StringElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): StringElement
@@ -253,7 +253,7 @@ interface StringElement : TextElement {
  * Includes no additional functionality over [TextElement], but serves to provide additional type safety when
  * working with elements that must be Ion symbols.
  */
-interface SymbolElement : TextElement {
+public interface SymbolElement : TextElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): SymbolElement
@@ -265,8 +265,8 @@ interface SymbolElement : TextElement {
 }
 
 /** Represents an Ion clob or blob. */
-interface LobElement : IonElement {
-    val bytesValue:  ByteArrayView
+public interface LobElement : IonElement {
+    public val bytesValue:  ByteArrayView
     override fun copy(annotations: List<String>, metas: MetaContainer): LobElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): LobElement
@@ -283,7 +283,7 @@ interface LobElement : IonElement {
  * Includes no additional functionality over [LobElement], but serves to provide additional type safety when
  * working with elements that must be Ion blobs.
  */
-interface BlobElement : LobElement {
+public interface BlobElement : LobElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): BlobElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): BlobElement
@@ -300,7 +300,7 @@ interface BlobElement : LobElement {
  * Includes no additional functionality over [LobElement], but serves to provide additional type safety when
  * working with elements that must be Ion clobs.
  */
-interface ClobElement : LobElement {
+public interface ClobElement : LobElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): ClobElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): ClobElement
@@ -323,11 +323,11 @@ interface ClobElement : LobElement {
  *
  * @see [IonElement]
  */
-interface ContainerElement : IonElement {
+public interface ContainerElement : IonElement {
     /** The number of values in this container. */
-    val size: Int
+    public val size: Int
 
-    val values: Collection<AnyElement>
+    public val values: Collection<AnyElement>
 
     override fun copy(annotations: List<String>, metas: MetaContainer): ContainerElement
 
@@ -351,7 +351,7 @@ interface ContainerElement : IonElement {
  *
  * @see [IonElement]
  */
-interface SeqElement : ContainerElement {
+public interface SeqElement : ContainerElement {
     /** Narrows the return type of [ContainerElement.values] to [List<AnyElement>]. */
     override val values: List<AnyElement>
 
@@ -376,7 +376,7 @@ interface SeqElement : ContainerElement {
  *
  * @see [IonElement]
  */
-interface ListElement : SeqElement {
+public interface ListElement : SeqElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): ListElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): ListElement
@@ -399,7 +399,7 @@ interface ListElement : SeqElement {
  *
  * @see [IonElement]
  */
-interface SexpElement : SeqElement {
+public interface SexpElement : SeqElement {
     override fun copy(annotations: List<String>, metas: MetaContainer): SexpElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): SexpElement
@@ -421,10 +421,10 @@ interface SexpElement : SeqElement {
  *
  * @see [IonElement]
  */
-interface StructElement : ContainerElement {
+public interface StructElement : ContainerElement {
 
     /** This struct's unordered collection of fields. */
-    val fields: Collection<StructField>
+    public val fields: Collection<StructField>
 
     /**
      * Retrieves the value of the first field found with the specified name.
@@ -433,17 +433,17 @@ interface StructElement : ContainerElement {
      *
      * @throws IonElementException If there are no fields with the specified [fieldName].
      */
-    operator fun get(fieldName: String): AnyElement
+    public operator fun get(fieldName: String): AnyElement
 
     /** The same as [get] but returns a null reference if the field does not exist.  */
-    fun getOptional(fieldName: String): AnyElement?
+    public fun getOptional(fieldName: String): AnyElement?
 
 
     /** Retrieves all values with a given field name. Returns an empty iterable if the field does not exist. */
-    fun getAll(fieldName: String): Iterable<AnyElement>
+    public fun getAll(fieldName: String): Iterable<AnyElement>
 
     /** Returns true if this StructElement has at least one field with the given field name. */
-    fun containsField(fieldName: String): Boolean
+    public fun containsField(fieldName: String): Boolean
 
     override fun copy(annotations: List<String>, metas: MetaContainer): StructElement
     override fun withAnnotations(vararg additionalAnnotations: String): StructElement

--- a/src/com/amazon/ionelement/api/IonElementException.kt
+++ b/src/com/amazon/ionelement/api/IonElementException.kt
@@ -18,14 +18,14 @@ package com.amazon.ionelement.api
 /**
  * Base exception which includes the [location] in the message if it was included at construction time.
  */
-open class IonElementException(
-    val location: IonLocation?,
-    val description: String,
+public open class IonElementException internal constructor(
+    public val location: IonLocation?,
+    public val description: String,
     cause: Throwable? = null
 ) : Error(locationToString(location) + ": $description", cause)
 
 /** Exception thrown by [IonElementLoader]. */
-class IonElementLoaderException(
+public class IonElementLoaderException internal constructor(
     location: IonLocation?,
     description: String,
     cause: Throwable? = null
@@ -36,10 +36,10 @@ class IonElementLoaderException(
  *
  * [blame] is the [IonElement] instance that violates the constraint.
  */
-class IonElementConstraintException(
+public class IonElementConstraintException internal constructor(
     private val elementToBlame: IonElement,
     description: String,
     cause: Throwable? = null
 ) : IonElementException(elementToBlame.metas.location, description, cause) {
-    val blame get() = elementToBlame.asAnyElement()
+    public val blame: AnyElement get() = elementToBlame.asAnyElement()
 }

--- a/src/com/amazon/ionelement/api/IonElementExtensions.kt
+++ b/src/com/amazon/ionelement/api/IonElementExtensions.kt
@@ -65,14 +65,14 @@ internal inline fun <reified T: IonElement> T._withoutMetas(): T =
  *
  * If the first element is not a symbol or this container has no elements, throws [IonElementException],
  */
-val SeqElement.tag get() = this.head.symbolValue
+public val SeqElement.tag: String get() = this.head.symbolValue
 
 /**
  * Returns the first element of this container.
  *
  * If this container has no elements, throws [IonElementException].
  */
-val SeqElement.head: AnyElement
+public val SeqElement.head: AnyElement
     get() =
         when (this.size) {
             0 -> constraintError(this, "Cannot get head of empty container")
@@ -84,15 +84,15 @@ val SeqElement.head: AnyElement
  *
  * If this container has no elements, throws [IonElementException].
  */
-val SeqElement.tail: List<AnyElement> get()  =
+public val SeqElement.tail: List<AnyElement> get()  =
     when (this.size) {
         0 -> constraintError(this, "Cannot get tail of empty container")
         else -> this.values.subList(1, this.size)
     }
 
 /** Returns the first element. */
-val List<AnyElement>.head get() =
-    this.first()
+public val List<AnyElement>.head: AnyElement
+    get() = this.first()
 
 /** Returns a copy of the list with the first element removed. */
-val List<AnyElement>.tail get() = this.subList(1, this.size)
+public val List<AnyElement>.tail: List<AnyElement> get() = this.subList(1, this.size)

--- a/src/com/amazon/ionelement/api/IonElementLoader.kt
+++ b/src/com/amazon/ionelement/api/IonElementLoader.kt
@@ -26,13 +26,13 @@ import com.amazon.ionelement.impl.IonElementLoaderImpl
  * current [IonLocation] if one is available.  Note that depending on the state of the [IonReader], a location
  * may not be available.
  */
-interface IonElementLoader {
+public interface IonElementLoader {
     /**
      * Reads a single element from the specified Ion text data.
      *
      * Throws an [IonElementLoaderException] if there are multiple top level elements.
      */
-    fun loadSingleElement(ionText: String): AnyElement
+    public fun loadSingleElement(ionText: String): AnyElement
 
     /**
      * Reads the next element from the specified [IonReader].
@@ -42,7 +42,7 @@ interface IonElementLoader {
      * If there are additional elements to be read after reading the next element,
      * throws an [IonElementLoaderException].
      */
-    fun loadSingleElement(ionReader: IonReader): AnyElement
+    public fun loadSingleElement(ionReader: IonReader): AnyElement
 
     /**
      * Reads all elements remaining to be read from the [IonReader].
@@ -52,7 +52,7 @@ interface IonElementLoader {
      * Avoid this function when reading large amounts of Ion because a large amount of memory will be consumed.
      * Instead, prefer [IonElementLoaderException].
      */
-    fun loadAllElements(ionReader: IonReader): Iterable<AnyElement>
+    public fun loadAllElements(ionReader: IonReader): Iterable<AnyElement>
 
     /**
      * Reads all of the elements in the specified Ion text data.
@@ -60,7 +60,7 @@ interface IonElementLoader {
      * Avoid this function when reading large amounts of Ion because a large amount of memory will be consumed.
      * Instead, prefer [processAll] or [loadCurrentElement].
      */
-    fun loadAllElements(ionText: String): Iterable<AnyElement>
+    public fun loadAllElements(ionText: String): Iterable<AnyElement>
 
     /**
      * Reads the current element from the specified [IonReader].  Does not close the [IonReader].
@@ -70,7 +70,7 @@ interface IonElementLoader {
      * This method can be utilized to fetch and process the elements one by one and can help avoid high memory
      * consumption when processing large amounts of Ion data.
      */
-    fun loadCurrentElement(ionReader: IonReader): AnyElement
+    public fun loadCurrentElement(ionReader: IonReader): AnyElement
 }
 
 /**
@@ -79,7 +79,7 @@ interface IonElementLoader {
  * While there is only one property here currently, new properties may be added to this class without breaking
  * source compatibility with prior versions of this library.
  */
-data class IonElementLoaderOptions(
+public data class IonElementLoaderOptions(
     /**
      * Set to true to cause `IonLocation` to be stored in the [IonElement.metas] collection of all elements loaded.
      *
@@ -90,30 +90,30 @@ data class IonElementLoaderOptions(
 
 /** Creates an [IonElementLoader] implementation with the specified [options]. */
 @JvmOverloads
-fun createIonElementLoader(options: IonElementLoaderOptions = IonElementLoaderOptions()): IonElementLoader =
+public fun createIonElementLoader(options: IonElementLoaderOptions = IonElementLoaderOptions()): IonElementLoader =
     IonElementLoaderImpl(options)
 
 /** Provides syntactically lighter way of invoking [IonElementLoader.loadSingleElement]. */
 @JvmOverloads
-fun loadSingleElement(ionText: String, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
+public fun loadSingleElement(ionText: String, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
     createIonElementLoader(options).loadSingleElement(ionText)
 
 /** Provides syntactically lighter method of invoking [IonElementLoader.loadSingleElement]. */
 @JvmOverloads
-fun loadSingleElement(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
+public fun loadSingleElement(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
     createIonElementLoader(options).loadSingleElement(ionReader)
 
 /** Provides syntactically lighter method of invoking [IonElementLoader.loadAllElements]. */
 @JvmOverloads
-fun loadAllElements(ionText: String, options: IonElementLoaderOptions = IonElementLoaderOptions()): Iterable<AnyElement> =
+public fun loadAllElements(ionText: String, options: IonElementLoaderOptions = IonElementLoaderOptions()): Iterable<AnyElement> =
     createIonElementLoader(options).loadAllElements(ionText)
 
 /** Provides syntactically lighter method of invoking [IonElementLoader.loadAllElements]. */
 @JvmOverloads
-fun loadAllElements(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): Iterable<AnyElement> =
+public fun loadAllElements(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): Iterable<AnyElement> =
     createIonElementLoader(options).loadAllElements(ionReader)
 
 /** Provides syntactically lighter method of invoking [IonElementLoader.loadAllElements]. */
 @JvmOverloads
-fun loadCurrentElement(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
+public fun loadCurrentElement(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
     createIonElementLoader(options).loadCurrentElement(ionReader)

--- a/src/com/amazon/ionelement/api/IonLocation.kt
+++ b/src/com/amazon/ionelement/api/IonLocation.kt
@@ -15,19 +15,19 @@
 
 package com.amazon.ionelement.api
 
-val ION_LOCATION_META_TAG = "\$ion_location"
+internal const val ION_LOCATION_META_TAG: String = "\$ion_location"
 
-sealed class IonLocation
+public sealed class IonLocation
 
-data class IonTextLocation(val line: Long, val charOffset: Long) : IonLocation() {
+public data class IonTextLocation(val line: Long, val charOffset: Long) : IonLocation() {
     override fun toString(): String = "$line:$charOffset"
 }
 
-data class IonBinaryLocation(val byteOffset: Long): IonLocation() {
+public data class IonBinaryLocation(val byteOffset: Long): IonLocation() {
     override fun toString(): String = byteOffset.toString()
 }
 
-fun locationToString(loc: IonLocation?) = loc?.toString() ?: "<unknown location>"
+public fun locationToString(loc: IonLocation?): String = loc?.toString() ?: "<unknown location>"
 
-val MetaContainer.location: IonLocation?
+public val MetaContainer.location: IonLocation?
     get() = this[ION_LOCATION_META_TAG] as? IonLocation

--- a/src/com/amazon/ionelement/api/IonMeta.kt
+++ b/src/com/amazon/ionelement/api/IonMeta.kt
@@ -19,22 +19,22 @@ package com.amazon.ionelement.api
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.toPersistentHashMap
 
-typealias MetaContainer = Map<String, Any>
+public typealias MetaContainer = Map<String, Any>
 internal typealias PersistentMetaContainer = PersistentMap<String, Any>
 
 internal val EMPTY_METAS = HashMap<String, Any>().toPersistentHashMap()
 
-fun emptyMetaContainer(): MetaContainer = EMPTY_METAS
+public fun emptyMetaContainer(): MetaContainer = EMPTY_METAS
 
-inline fun <reified T> MetaContainer.metaOrNull(key: String): T? = this[key] as T
-inline fun <reified T> MetaContainer.meta(key: String): T =
+public inline fun <reified T> MetaContainer.metaOrNull(key: String): T? = this[key] as T
+public inline fun <reified T> MetaContainer.meta(key: String): T =
     metaOrNull(key) ?: error("Meta with key '$key' and type ${T::class.java} not found in MetaContainer")
 
 
-fun metaContainerOf(kvps: List<Pair<String, Any>>) =
+public fun metaContainerOf(kvps: List<Pair<String, Any>>): MetaContainer =
     metaContainerOf(*kvps.toTypedArray())
 
-fun metaContainerOf(vararg kvps: Pair<String, Any>) =
+public fun metaContainerOf(vararg kvps: Pair<String, Any>): MetaContainer =
     when {
         kvps.none() -> EMPTY_METAS
         else -> HashMap(mapOf(*kvps))
@@ -44,13 +44,13 @@ fun metaContainerOf(vararg kvps: Pair<String, Any>) =
  * Merges two meta containers.  Any keys present in the receiver will be replaced by any keys in with the same
  * name in [other].
  */
-operator fun MetaContainer.plus(other: MetaContainer): MetaContainer =
+public operator fun MetaContainer.plus(other: MetaContainer): MetaContainer =
     HashMap<String, Any>(this.toList().union(other.toList()).toMap())
 
 /**
  * Merges two meta containers.  Any keys present in the receiver will be replaced by any keys in with the same
  * name in [other].
  */
-operator fun MetaContainer.plus(other: Iterable<Pair<String, Any>>): MetaContainer =
+public operator fun MetaContainer.plus(other: Iterable<Pair<String, Any>>): MetaContainer =
     HashMap<String, Any>(this.toList().union(other).toMap())
 

--- a/src/com/amazon/ionelement/api/IonUtils.kt
+++ b/src/com/amazon/ionelement/api/IonUtils.kt
@@ -27,7 +27,7 @@ import com.amazon.ion.ValueFactory
  * @param factory A [ValueFactory] to use to create the new [IonValue] instances.  Note that any
  * [com.amazon.ion.IonSystem] instance maybe be used here, in addition to other implementations of [ValueFactory].
  */
-fun IonElement.toIonValue(factory: ValueFactory): IonValue {
+public fun IonElement.toIonValue(factory: ValueFactory): IonValue {
     // We still have to use IonSystem under the covers for this to get an IonWriter that writes to a dummy list.
     val dummyList = factory.newList()
     dummyList.system.newWriter(dummyList).use { writer ->
@@ -43,7 +43,7 @@ fun IonElement.toIonValue(factory: ValueFactory): IonValue {
  *
  * New code that does not need to integrate with uses of the mutable DOM should not use this.
  */
-fun IonValue.toIonElement(): AnyElement =
+public fun IonValue.toIonElement(): AnyElement =
     this.system.newReader(this).use { reader->
         createIonElementLoader().loadSingleElement(reader)
     }

--- a/src/com/amazon/ionelement/api/StructField.kt
+++ b/src/com/amazon/ionelement/api/StructField.kt
@@ -18,11 +18,11 @@ package com.amazon.ionelement.api
 /**
  * A field within an Ion struct.
  */
-interface StructField {
-    val name: String
-    val value: AnyElement
+public interface StructField {
+    public val name: String
+    public val value: AnyElement
 
-    operator fun component1(): String
-    operator fun component2(): AnyElement
+    public operator fun component1(): String
+    public operator fun component2(): AnyElement
 }
 

--- a/src/com/amazon/ionelement/impl/ByteArrayViewImpl.kt
+++ b/src/com/amazon/ionelement/impl/ByteArrayViewImpl.kt
@@ -2,7 +2,7 @@ package com.amazon.ionelement.impl
 
 import com.amazon.ionelement.api.ByteArrayView
 
-class ByteArrayViewImpl(private val bytes: ByteArray) : ByteArrayView {
+internal class ByteArrayViewImpl(private val bytes: ByteArray) : ByteArrayView {
     override fun size(): Int = bytes.size
 
     override fun get(index: Int): Byte = bytes[index]

--- a/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -25,7 +25,7 @@ import com.amazon.ion.TextSpan
 import com.amazon.ion.system.IonReaderBuilder
 import com.amazon.ionelement.api.*
 
-class IonElementLoaderImpl(private val options: IonElementLoaderOptions) : IonElementLoader {
+internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions) : IonElementLoader {
 
     /**
      * Catches an [IonException] occurring in [block] and throws an [IonElementLoaderException] with


### PR DESCRIPTION
**Issue #, if available:**

Fixes #47

**Description of changes:**

Enables [Explicit API mode](https://github.com/Kotlin/KEEP/blob/master/proposals/explicit-api-mode.md). This requires us to be explicit about what is part of the API, and to be explicit about the return types of any public functions.

In most cases, it was obvious that the class/interface/val/fun should be public, but there are a few cases that I was not completely sure about.

* `typealias Annotations` -- appears to only be used internally, but another typealias (`MetaContainer`) does already have confirmed external usage.
* `IonElementException` constructors -- while the exceptions themselves should be public, should the constructors be public?

In both cases, I have chosen to be conservative and label them as internal, but I'm definitely open to be convinced otherwise.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

