### PR TITLE
Adds Ktlint and Kotlin/binary-compatibility-validator checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+ij_kotlin_imports_layout = *
+ij_kotlin_packages_to_use_import_on_demand=com.amazon.ionelement.**
+
+[test/**.kt]
+ktlint_ignore_back_ticked_identifier=true

--- a/README.md
+++ b/README.md
@@ -531,22 +531,44 @@ This repository contains the [ion-tests](https://github.com/amzn/ion-tests) repo
 a [git submodule](https://git-scm.com/docs/git-submodule). The easiest way to clone the `ion-element-kotlin` repository
 and initialize its submodule is to run the following command:
 
-```
-$ git clone --recursive https://github.com/amzn/ion-element-kotlin.git ion-element-kotlin
+```shell
+git clone --recursive https://github.com/amzn/ion-element-kotlin.git ion-element-kotlin
 ```
 
 Alternatively, the submodule may be initialized independently of the clone by running the following commands:
 
-```
-$ git submodule init
-$ git submodule update
+```shell
+git submodule init
+git submodule update
 ```
 
 `ion-element-kotlin` may now be built with the following command:
 
+```shell
+./gradlew build
 ```
-$ ./gradlew build
+
+### Code Style Check
+
+This project uses [ktlint](https://github.com/pinterest/ktlint) to enforce the official Kotlin code conventions.
+To automatically correct (most) style violations, run:
+```shell
+./gradlew ktlintFormat
 ```
+
+### Binary Compatibility Check
+
+This project uses [Kotlin/binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator) to 
+prevent accidental changes to the binary API of the library. The `apiCheck` task will be run as part of the Gradle 
+`check` task, and it will fail if the current build differs in any way from the API that is persisted in `api/IonElement.api`.
+If you are intentionally changing the API, update the persisted API definition by running:
+```shell
+./gradlew apiDump && git add api
+```
+
+When preparing a release, you can use the diff of `api/IonElement.api` to help determine whether a release should be a 
+new major, minor, or patch version. If the file has no changes, it _may_ be a patch release. If the file has only 
+additive changes, it _may_ be a minor version. Any other changes indicate that a new major version is required.
 
 ### Pulling in Upstream Changes
 
@@ -554,8 +576,8 @@ To pull upstream changes into `ion-element-kotlin`, start with a simple `git pul
 to `ion-element-kotlin` itself (including any changes to its `.gitmodules` file), but not any changes to the submodules.
 To make sure the submodules are up-to-date, use the following command:
 
-```
-$ git submodule update --remote
+```shell
+git submodule update --remote
 ```
 
 For detailed walkthroughs of git submodule usage, see the

--- a/api/IonElement.api
+++ b/api/IonElement.api
@@ -1,0 +1,531 @@
+public abstract interface class com/amazon/ionelement/api/AnyElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun asBlob ()Lcom/amazon/ionelement/api/BlobElement;
+	public abstract fun asBlobOrNull ()Lcom/amazon/ionelement/api/BlobElement;
+	public abstract fun asBoolean ()Lcom/amazon/ionelement/api/BoolElement;
+	public abstract fun asBooleanOrNull ()Lcom/amazon/ionelement/api/BoolElement;
+	public abstract fun asClob ()Lcom/amazon/ionelement/api/ClobElement;
+	public abstract fun asClobOrNull ()Lcom/amazon/ionelement/api/ClobElement;
+	public abstract fun asContainer ()Lcom/amazon/ionelement/api/ContainerElement;
+	public abstract fun asContainerOrNull ()Lcom/amazon/ionelement/api/ContainerElement;
+	public abstract fun asDecimal ()Lcom/amazon/ionelement/api/DecimalElement;
+	public abstract fun asDecimalOrNull ()Lcom/amazon/ionelement/api/DecimalElement;
+	public abstract fun asFloat ()Lcom/amazon/ionelement/api/FloatElement;
+	public abstract fun asFloatOrNull ()Lcom/amazon/ionelement/api/FloatElement;
+	public abstract fun asInt ()Lcom/amazon/ionelement/api/IntElement;
+	public abstract fun asIntOrNull ()Lcom/amazon/ionelement/api/IntElement;
+	public abstract fun asList ()Lcom/amazon/ionelement/api/ListElement;
+	public abstract fun asListOrNull ()Lcom/amazon/ionelement/api/ListElement;
+	public abstract fun asLob ()Lcom/amazon/ionelement/api/LobElement;
+	public abstract fun asLobOrNull ()Lcom/amazon/ionelement/api/LobElement;
+	public abstract fun asSeq ()Lcom/amazon/ionelement/api/SeqElement;
+	public abstract fun asSeqOrNull ()Lcom/amazon/ionelement/api/SeqElement;
+	public abstract fun asSexp ()Lcom/amazon/ionelement/api/SexpElement;
+	public abstract fun asSexpOrNull ()Lcom/amazon/ionelement/api/SexpElement;
+	public abstract fun asString ()Lcom/amazon/ionelement/api/StringElement;
+	public abstract fun asStringOrNull ()Lcom/amazon/ionelement/api/StringElement;
+	public abstract fun asStruct ()Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun asStructOrNull ()Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun asSymbol ()Lcom/amazon/ionelement/api/SymbolElement;
+	public abstract fun asSymbolOrNull ()Lcom/amazon/ionelement/api/SymbolElement;
+	public abstract fun asText ()Lcom/amazon/ionelement/api/TextElement;
+	public abstract fun asTextOrNull ()Lcom/amazon/ionelement/api/TextElement;
+	public abstract fun asTimestamp ()Lcom/amazon/ionelement/api/TimestampElement;
+	public abstract fun asTimestampOrNull ()Lcom/amazon/ionelement/api/TimestampElement;
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun getBigIntegerValue ()Ljava/math/BigInteger;
+	public abstract fun getBigIntegerValueOrNull ()Ljava/math/BigInteger;
+	public abstract fun getBlobValue ()Lcom/amazon/ionelement/api/ByteArrayView;
+	public abstract fun getBlobValueOrNull ()Lcom/amazon/ionelement/api/ByteArrayView;
+	public abstract fun getBooleanValue ()Z
+	public abstract fun getBooleanValueOrNull ()Ljava/lang/Boolean;
+	public abstract fun getBytesValue ()Lcom/amazon/ionelement/api/ByteArrayView;
+	public abstract fun getBytesValueOrNull ()Lcom/amazon/ionelement/api/ByteArrayView;
+	public abstract fun getClobValue ()Lcom/amazon/ionelement/api/ByteArrayView;
+	public abstract fun getClobValueOrNull ()Lcom/amazon/ionelement/api/ByteArrayView;
+	public abstract fun getContainerValues ()Ljava/util/Collection;
+	public abstract fun getContainerValuesOrNull ()Ljava/util/Collection;
+	public abstract fun getDecimalValue ()Lcom/amazon/ion/Decimal;
+	public abstract fun getDecimalValueOrNull ()Lcom/amazon/ion/Decimal;
+	public abstract fun getDoubleValue ()D
+	public abstract fun getDoubleValueOrNull ()Ljava/lang/Double;
+	public abstract fun getIntegerSize ()Lcom/amazon/ionelement/api/IntElementSize;
+	public abstract fun getListValues ()Ljava/util/List;
+	public abstract fun getListValuesOrNull ()Ljava/util/List;
+	public abstract fun getLongValue ()J
+	public abstract fun getLongValueOrNull ()Ljava/lang/Long;
+	public abstract fun getSeqValues ()Ljava/util/List;
+	public abstract fun getSeqValuesOrNull ()Ljava/util/List;
+	public abstract fun getSexpValues ()Ljava/util/List;
+	public abstract fun getSexpValuesOrNull ()Ljava/util/List;
+	public abstract fun getStringValue ()Ljava/lang/String;
+	public abstract fun getStringValueOrNull ()Ljava/lang/String;
+	public abstract fun getStructFields ()Ljava/util/Collection;
+	public abstract fun getStructFieldsOrNull ()Ljava/util/Collection;
+	public abstract fun getSymbolValue ()Ljava/lang/String;
+	public abstract fun getSymbolValueOrNull ()Ljava/lang/String;
+	public abstract fun getTextValue ()Ljava/lang/String;
+	public abstract fun getTextValueOrNull ()Ljava/lang/String;
+	public abstract fun getTimestampValue ()Lcom/amazon/ion/Timestamp;
+	public abstract fun getTimestampValueOrNull ()Lcom/amazon/ion/Timestamp;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/AnyElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/BlobElement : com/amazon/ionelement/api/LobElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/BlobElement;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/BlobElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/BlobElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/BlobElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/BlobElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/BlobElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/BlobElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/BoolElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/BoolElement;
+	public abstract fun getBooleanValue ()Z
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/BoolElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/BoolElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/BoolElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/BoolElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/BoolElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/BoolElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/ByteArrayView : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public abstract fun copyOfBytes ()[B
+	public abstract fun get (I)B
+	public abstract fun size ()I
+}
+
+public abstract interface class com/amazon/ionelement/api/ClobElement : com/amazon/ionelement/api/LobElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/ClobElement;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/ClobElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/ClobElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/ClobElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/ClobElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/ClobElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/ClobElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/ContainerElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/ContainerElement;
+	public abstract fun getSize ()I
+	public abstract fun getValues ()Ljava/util/Collection;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/ContainerElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/ContainerElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/ContainerElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/ContainerElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/ContainerElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/ContainerElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/DecimalElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/DecimalElement;
+	public abstract fun getDecimalValue ()Lcom/amazon/ion/Decimal;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/DecimalElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/DecimalElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/DecimalElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/DecimalElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/DecimalElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/DecimalElement;
+}
+
+public final class com/amazon/ionelement/api/ElementLoader {
+	public static final fun createIonElementLoader ()Lcom/amazon/ionelement/api/IonElementLoader;
+	public static final fun createIonElementLoader (Lcom/amazon/ionelement/api/IonElementLoaderOptions;)Lcom/amazon/ionelement/api/IonElementLoader;
+	public static synthetic fun createIonElementLoader$default (Lcom/amazon/ionelement/api/IonElementLoaderOptions;ILjava/lang/Object;)Lcom/amazon/ionelement/api/IonElementLoader;
+	public static final fun loadAllElements (Lcom/amazon/ion/IonReader;)Ljava/lang/Iterable;
+	public static final fun loadAllElements (Lcom/amazon/ion/IonReader;Lcom/amazon/ionelement/api/IonElementLoaderOptions;)Ljava/lang/Iterable;
+	public static final fun loadAllElements (Ljava/lang/String;)Ljava/lang/Iterable;
+	public static final fun loadAllElements (Ljava/lang/String;Lcom/amazon/ionelement/api/IonElementLoaderOptions;)Ljava/lang/Iterable;
+	public static synthetic fun loadAllElements$default (Lcom/amazon/ion/IonReader;Lcom/amazon/ionelement/api/IonElementLoaderOptions;ILjava/lang/Object;)Ljava/lang/Iterable;
+	public static synthetic fun loadAllElements$default (Ljava/lang/String;Lcom/amazon/ionelement/api/IonElementLoaderOptions;ILjava/lang/Object;)Ljava/lang/Iterable;
+	public static final fun loadCurrentElement (Lcom/amazon/ion/IonReader;)Lcom/amazon/ionelement/api/AnyElement;
+	public static final fun loadCurrentElement (Lcom/amazon/ion/IonReader;Lcom/amazon/ionelement/api/IonElementLoaderOptions;)Lcom/amazon/ionelement/api/AnyElement;
+	public static synthetic fun loadCurrentElement$default (Lcom/amazon/ion/IonReader;Lcom/amazon/ionelement/api/IonElementLoaderOptions;ILjava/lang/Object;)Lcom/amazon/ionelement/api/AnyElement;
+	public static final fun loadSingleElement (Lcom/amazon/ion/IonReader;)Lcom/amazon/ionelement/api/AnyElement;
+	public static final fun loadSingleElement (Lcom/amazon/ion/IonReader;Lcom/amazon/ionelement/api/IonElementLoaderOptions;)Lcom/amazon/ionelement/api/AnyElement;
+	public static final fun loadSingleElement (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
+	public static final fun loadSingleElement (Ljava/lang/String;Lcom/amazon/ionelement/api/IonElementLoaderOptions;)Lcom/amazon/ionelement/api/AnyElement;
+	public static synthetic fun loadSingleElement$default (Lcom/amazon/ion/IonReader;Lcom/amazon/ionelement/api/IonElementLoaderOptions;ILjava/lang/Object;)Lcom/amazon/ionelement/api/AnyElement;
+	public static synthetic fun loadSingleElement$default (Ljava/lang/String;Lcom/amazon/ionelement/api/IonElementLoaderOptions;ILjava/lang/Object;)Lcom/amazon/ionelement/api/AnyElement;
+}
+
+public final class com/amazon/ionelement/api/ElementType : java/lang/Enum {
+	public static final field BLOB Lcom/amazon/ionelement/api/ElementType;
+	public static final field BOOL Lcom/amazon/ionelement/api/ElementType;
+	public static final field CLOB Lcom/amazon/ionelement/api/ElementType;
+	public static final field DECIMAL Lcom/amazon/ionelement/api/ElementType;
+	public static final field FLOAT Lcom/amazon/ionelement/api/ElementType;
+	public static final field INT Lcom/amazon/ionelement/api/ElementType;
+	public static final field LIST Lcom/amazon/ionelement/api/ElementType;
+	public static final field NULL Lcom/amazon/ionelement/api/ElementType;
+	public static final field SEXP Lcom/amazon/ionelement/api/ElementType;
+	public static final field STRING Lcom/amazon/ionelement/api/ElementType;
+	public static final field STRUCT Lcom/amazon/ionelement/api/ElementType;
+	public static final field SYMBOL Lcom/amazon/ionelement/api/ElementType;
+	public static final field TIMESTAMP Lcom/amazon/ionelement/api/ElementType;
+	public final fun isContainer ()Z
+	public final fun isLob ()Z
+	public final fun isSeq ()Z
+	public final fun isText ()Z
+	public final fun toIonType ()Lcom/amazon/ion/IonType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/amazon/ionelement/api/ElementType;
+	public static fun values ()[Lcom/amazon/ionelement/api/ElementType;
+}
+
+public final class com/amazon/ionelement/api/ElementTypeKt {
+	public static final fun toElementType (Lcom/amazon/ion/IonType;)Lcom/amazon/ionelement/api/ElementType;
+}
+
+public abstract interface class com/amazon/ionelement/api/FloatElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/FloatElement;
+	public abstract fun getDoubleValue ()D
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/FloatElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/FloatElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/FloatElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/FloatElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/FloatElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/FloatElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/IntElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/IntElement;
+	public abstract fun getBigIntegerValue ()Ljava/math/BigInteger;
+	public abstract fun getIntegerSize ()Lcom/amazon/ionelement/api/IntElementSize;
+	public abstract fun getLongValue ()J
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/IntElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/IntElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/IntElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/IntElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/IntElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/IntElement;
+}
+
+public final class com/amazon/ionelement/api/IntElementSize : java/lang/Enum {
+	public static final field BIG_INTEGER Lcom/amazon/ionelement/api/IntElementSize;
+	public static final field LONG Lcom/amazon/ionelement/api/IntElementSize;
+	public static fun valueOf (Ljava/lang/String;)Lcom/amazon/ionelement/api/IntElementSize;
+	public static fun values ()[Lcom/amazon/ionelement/api/IntElementSize;
+}
+
+public final class com/amazon/ionelement/api/Ion {
+	public static final fun emptyBlob ()Lcom/amazon/ionelement/api/BlobElement;
+	public static final fun emptyClob ()Lcom/amazon/ionelement/api/ClobElement;
+	public static final fun emptyIonList ()Lcom/amazon/ionelement/api/ListElement;
+	public static final fun emptyIonSexp ()Lcom/amazon/ionelement/api/SexpElement;
+	public static final fun emptyIonStruct ()Lcom/amazon/ionelement/api/StructElement;
+	public static final fun field (Ljava/lang/String;Lcom/amazon/ionelement/api/IonElement;)Lcom/amazon/ionelement/api/StructField;
+	public static final fun ionBlob ([B)Lcom/amazon/ionelement/api/BlobElement;
+	public static final fun ionBlob ([BLjava/util/List;)Lcom/amazon/ionelement/api/BlobElement;
+	public static final fun ionBlob ([BLjava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/BlobElement;
+	public static final fun ionBlob ([BLjava/util/Map;)Lcom/amazon/ionelement/api/BlobElement;
+	public static synthetic fun ionBlob$default ([BLjava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/BlobElement;
+	public static final fun ionBool (Z)Lcom/amazon/ionelement/api/BoolElement;
+	public static final fun ionBool (ZLjava/util/List;)Lcom/amazon/ionelement/api/BoolElement;
+	public static final fun ionBool (ZLjava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/BoolElement;
+	public static final fun ionBool (ZLjava/util/Map;)Lcom/amazon/ionelement/api/BoolElement;
+	public static synthetic fun ionBool$default (ZLjava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/BoolElement;
+	public static final fun ionClob ([B)Lcom/amazon/ionelement/api/ClobElement;
+	public static final fun ionClob ([BLjava/util/List;)Lcom/amazon/ionelement/api/ClobElement;
+	public static final fun ionClob ([BLjava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/ClobElement;
+	public static final fun ionClob ([BLjava/util/Map;)Lcom/amazon/ionelement/api/ClobElement;
+	public static synthetic fun ionClob$default ([BLjava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/ClobElement;
+	public static synthetic fun ionClob$default ([BLjava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/ClobElement;
+	public static final fun ionDecimal (Lcom/amazon/ion/Decimal;)Lcom/amazon/ionelement/api/DecimalElement;
+	public static final fun ionDecimal (Lcom/amazon/ion/Decimal;Ljava/util/List;)Lcom/amazon/ionelement/api/DecimalElement;
+	public static final fun ionDecimal (Lcom/amazon/ion/Decimal;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/DecimalElement;
+	public static final fun ionDecimal (Lcom/amazon/ion/Decimal;Ljava/util/Map;)Lcom/amazon/ionelement/api/DecimalElement;
+	public static synthetic fun ionDecimal$default (Lcom/amazon/ion/Decimal;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/DecimalElement;
+	public static final fun ionFloat (D)Lcom/amazon/ionelement/api/FloatElement;
+	public static final fun ionFloat (DLjava/util/List;)Lcom/amazon/ionelement/api/FloatElement;
+	public static final fun ionFloat (DLjava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/FloatElement;
+	public static final fun ionFloat (DLjava/util/Map;)Lcom/amazon/ionelement/api/FloatElement;
+	public static synthetic fun ionFloat$default (DLjava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/FloatElement;
+	public static final fun ionInt (J)Lcom/amazon/ionelement/api/IntElement;
+	public static final fun ionInt (JLjava/util/List;)Lcom/amazon/ionelement/api/IntElement;
+	public static final fun ionInt (JLjava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/IntElement;
+	public static final fun ionInt (JLjava/util/Map;)Lcom/amazon/ionelement/api/IntElement;
+	public static final fun ionInt (Ljava/math/BigInteger;)Lcom/amazon/ionelement/api/IntElement;
+	public static final fun ionInt (Ljava/math/BigInteger;Ljava/util/List;)Lcom/amazon/ionelement/api/IntElement;
+	public static final fun ionInt (Ljava/math/BigInteger;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/IntElement;
+	public static final fun ionInt (Ljava/math/BigInteger;Ljava/util/Map;)Lcom/amazon/ionelement/api/IntElement;
+	public static synthetic fun ionInt$default (JLjava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/IntElement;
+	public static synthetic fun ionInt$default (Ljava/math/BigInteger;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/IntElement;
+	public static final fun ionListOf (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/ListElement;
+	public static final fun ionListOf (Ljava/lang/Iterable;Ljava/util/List;)Lcom/amazon/ionelement/api/ListElement;
+	public static final fun ionListOf (Ljava/lang/Iterable;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/ListElement;
+	public static final fun ionListOf (Ljava/lang/Iterable;Ljava/util/Map;)Lcom/amazon/ionelement/api/ListElement;
+	public static final fun ionListOf ([Lcom/amazon/ionelement/api/IonElement;)Lcom/amazon/ionelement/api/ListElement;
+	public static final fun ionListOf ([Lcom/amazon/ionelement/api/IonElement;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/ListElement;
+	public static synthetic fun ionListOf$default (Ljava/lang/Iterable;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/ListElement;
+	public static synthetic fun ionListOf$default ([Lcom/amazon/ionelement/api/IonElement;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/ListElement;
+	public static final fun ionNull ()Lcom/amazon/ionelement/api/IonElement;
+	public static final fun ionNull (Lcom/amazon/ionelement/api/ElementType;)Lcom/amazon/ionelement/api/IonElement;
+	public static final fun ionNull (Lcom/amazon/ionelement/api/ElementType;Ljava/util/List;)Lcom/amazon/ionelement/api/IonElement;
+	public static final fun ionNull (Lcom/amazon/ionelement/api/ElementType;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/IonElement;
+	public static final fun ionNull (Lcom/amazon/ionelement/api/ElementType;Ljava/util/Map;)Lcom/amazon/ionelement/api/IonElement;
+	public static synthetic fun ionNull$default (Lcom/amazon/ionelement/api/ElementType;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/IonElement;
+	public static synthetic fun ionNull$default (Lcom/amazon/ionelement/api/ElementType;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/IonElement;
+	public static final fun ionSexpOf (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/SexpElement;
+	public static final fun ionSexpOf (Ljava/lang/Iterable;Ljava/util/List;)Lcom/amazon/ionelement/api/SexpElement;
+	public static final fun ionSexpOf (Ljava/lang/Iterable;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/SexpElement;
+	public static final fun ionSexpOf (Ljava/lang/Iterable;Ljava/util/Map;)Lcom/amazon/ionelement/api/SexpElement;
+	public static final fun ionSexpOf ([Lcom/amazon/ionelement/api/IonElement;)Lcom/amazon/ionelement/api/SexpElement;
+	public static final fun ionSexpOf ([Lcom/amazon/ionelement/api/IonElement;Ljava/util/List;)Lcom/amazon/ionelement/api/SexpElement;
+	public static final fun ionSexpOf ([Lcom/amazon/ionelement/api/IonElement;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/SexpElement;
+	public static synthetic fun ionSexpOf$default (Ljava/lang/Iterable;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/SexpElement;
+	public static synthetic fun ionSexpOf$default ([Lcom/amazon/ionelement/api/IonElement;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/SexpElement;
+	public static final fun ionString (Ljava/lang/String;)Lcom/amazon/ionelement/api/StringElement;
+	public static final fun ionString (Ljava/lang/String;Ljava/util/List;)Lcom/amazon/ionelement/api/StringElement;
+	public static final fun ionString (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/StringElement;
+	public static final fun ionString (Ljava/lang/String;Ljava/util/Map;)Lcom/amazon/ionelement/api/StringElement;
+	public static synthetic fun ionString$default (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/StringElement;
+	public static final fun ionStructOf (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf (Ljava/lang/Iterable;Ljava/util/List;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf (Ljava/lang/Iterable;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf (Ljava/lang/Iterable;Ljava/util/Map;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf ([Lcom/amazon/ionelement/api/StructField;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf ([Lcom/amazon/ionelement/api/StructField;Ljava/util/List;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf ([Lcom/amazon/ionelement/api/StructField;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf ([Lkotlin/Pair;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf ([Lkotlin/Pair;Ljava/util/List;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionStructOf ([Lkotlin/Pair;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/StructElement;
+	public static synthetic fun ionStructOf$default (Ljava/lang/Iterable;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/StructElement;
+	public static synthetic fun ionStructOf$default ([Lcom/amazon/ionelement/api/StructField;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/StructElement;
+	public static synthetic fun ionStructOf$default ([Lkotlin/Pair;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/StructElement;
+	public static final fun ionSymbol (Ljava/lang/String;)Lcom/amazon/ionelement/api/SymbolElement;
+	public static final fun ionSymbol (Ljava/lang/String;Ljava/util/List;)Lcom/amazon/ionelement/api/SymbolElement;
+	public static final fun ionSymbol (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/SymbolElement;
+	public static final fun ionSymbol (Ljava/lang/String;Ljava/util/Map;)Lcom/amazon/ionelement/api/SymbolElement;
+	public static synthetic fun ionSymbol$default (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/SymbolElement;
+	public static final fun ionTimestamp (Lcom/amazon/ion/Timestamp;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static final fun ionTimestamp (Lcom/amazon/ion/Timestamp;Ljava/util/List;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static final fun ionTimestamp (Lcom/amazon/ion/Timestamp;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static final fun ionTimestamp (Lcom/amazon/ion/Timestamp;Ljava/util/Map;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static final fun ionTimestamp (Ljava/lang/String;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static final fun ionTimestamp (Ljava/lang/String;Ljava/util/List;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static final fun ionTimestamp (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static final fun ionTimestamp (Ljava/lang/String;Ljava/util/Map;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static synthetic fun ionTimestamp$default (Lcom/amazon/ion/Timestamp;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/TimestampElement;
+	public static synthetic fun ionTimestamp$default (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/TimestampElement;
+}
+
+public final class com/amazon/ionelement/api/IonBinaryLocation : com/amazon/ionelement/api/IonLocation {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lcom/amazon/ionelement/api/IonBinaryLocation;
+	public static synthetic fun copy$default (Lcom/amazon/ionelement/api/IonBinaryLocation;JILjava/lang/Object;)Lcom/amazon/ionelement/api/IonBinaryLocation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getByteOffset ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/amazon/ionelement/api/IonElement {
+	public abstract fun asAnyElement ()Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/IonElement;
+	public abstract fun getAnnotations ()Ljava/util/List;
+	public abstract fun getMetas ()Ljava/util/Map;
+	public abstract fun getType ()Lcom/amazon/ionelement/api/ElementType;
+	public abstract fun isNull ()Z
+	public abstract fun toString ()Ljava/lang/String;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/IonElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/IonElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/IonElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/IonElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/IonElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/IonElement;
+	public abstract fun writeTo (Lcom/amazon/ion/IonWriter;)V
+}
+
+public final class com/amazon/ionelement/api/IonElement$DefaultImpls {
+	public static synthetic fun copy$default (Lcom/amazon/ionelement/api/IonElement;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lcom/amazon/ionelement/api/IonElement;
+}
+
+public final class com/amazon/ionelement/api/IonElementConstraintException : com/amazon/ionelement/api/IonElementException {
+	public final fun getBlame ()Lcom/amazon/ionelement/api/AnyElement;
+}
+
+public class com/amazon/ionelement/api/IonElementException : java/lang/Error {
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getLocation ()Lcom/amazon/ionelement/api/IonLocation;
+}
+
+public final class com/amazon/ionelement/api/IonElementExtensionsKt {
+	public static final fun getHead (Lcom/amazon/ionelement/api/SeqElement;)Lcom/amazon/ionelement/api/AnyElement;
+	public static final fun getHead (Ljava/util/List;)Lcom/amazon/ionelement/api/AnyElement;
+	public static final fun getTag (Lcom/amazon/ionelement/api/SeqElement;)Ljava/lang/String;
+	public static final fun getTail (Lcom/amazon/ionelement/api/SeqElement;)Ljava/util/List;
+	public static final fun getTail (Ljava/util/List;)Ljava/util/List;
+}
+
+public abstract interface class com/amazon/ionelement/api/IonElementLoader {
+	public abstract fun loadAllElements (Lcom/amazon/ion/IonReader;)Ljava/lang/Iterable;
+	public abstract fun loadAllElements (Ljava/lang/String;)Ljava/lang/Iterable;
+	public abstract fun loadCurrentElement (Lcom/amazon/ion/IonReader;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun loadSingleElement (Lcom/amazon/ion/IonReader;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun loadSingleElement (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
+}
+
+public final class com/amazon/ionelement/api/IonElementLoaderException : com/amazon/ionelement/api/IonElementException {
+}
+
+public final class com/amazon/ionelement/api/IonElementLoaderOptions {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/amazon/ionelement/api/IonElementLoaderOptions;
+	public static synthetic fun copy$default (Lcom/amazon/ionelement/api/IonElementLoaderOptions;ZILjava/lang/Object;)Lcom/amazon/ionelement/api/IonElementLoaderOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeLocationMeta ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/amazon/ionelement/api/IonLocation {
+}
+
+public final class com/amazon/ionelement/api/IonLocationKt {
+	public static final fun getLocation (Ljava/util/Map;)Lcom/amazon/ionelement/api/IonLocation;
+	public static final fun locationToString (Lcom/amazon/ionelement/api/IonLocation;)Ljava/lang/String;
+}
+
+public final class com/amazon/ionelement/api/IonMeta {
+	public static final fun emptyMetaContainer ()Ljava/util/Map;
+	public static final fun metaContainerOf (Ljava/util/List;)Ljava/util/Map;
+	public static final fun metaContainerOf ([Lkotlin/Pair;)Ljava/util/Map;
+	public static final fun plus (Ljava/util/Map;Ljava/lang/Iterable;)Ljava/util/Map;
+	public static final fun plus (Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
+}
+
+public final class com/amazon/ionelement/api/IonTextLocation : com/amazon/ionelement/api/IonLocation {
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lcom/amazon/ionelement/api/IonTextLocation;
+	public static synthetic fun copy$default (Lcom/amazon/ionelement/api/IonTextLocation;JJILjava/lang/Object;)Lcom/amazon/ionelement/api/IonTextLocation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCharOffset ()J
+	public final fun getLine ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amazon/ionelement/api/IonUtils {
+	public static final fun toIonElement (Lcom/amazon/ion/IonValue;)Lcom/amazon/ionelement/api/AnyElement;
+	public static final fun toIonValue (Lcom/amazon/ionelement/api/IonElement;Lcom/amazon/ion/ValueFactory;)Lcom/amazon/ion/IonValue;
+}
+
+public abstract interface class com/amazon/ionelement/api/ListElement : com/amazon/ionelement/api/SeqElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/ListElement;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/ListElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/ListElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/ListElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/ListElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/ListElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/ListElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/LobElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/LobElement;
+	public abstract fun getBytesValue ()Lcom/amazon/ionelement/api/ByteArrayView;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/LobElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/LobElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/LobElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/LobElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/LobElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/LobElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/SeqElement : com/amazon/ionelement/api/ContainerElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/SeqElement;
+	public abstract fun getValues ()Ljava/util/List;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/SeqElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/SeqElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/SeqElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/SeqElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/SeqElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/SeqElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/SexpElement : com/amazon/ionelement/api/SeqElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/SexpElement;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/SexpElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/SexpElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/SexpElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/SexpElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/SexpElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/SexpElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/StringElement : com/amazon/ionelement/api/TextElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/StringElement;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/StringElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/StringElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/StringElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/StringElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/StringElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/StringElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/StructElement : com/amazon/ionelement/api/ContainerElement {
+	public abstract fun containsField (Ljava/lang/String;)Z
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun get (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun getAll (Ljava/lang/String;)Ljava/lang/Iterable;
+	public abstract fun getFields ()Ljava/util/Collection;
+	public abstract fun getOptional (Ljava/lang/String;)Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/StructElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/StructElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/StructField {
+	public abstract fun component1 ()Ljava/lang/String;
+	public abstract fun component2 ()Lcom/amazon/ionelement/api/AnyElement;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getValue ()Lcom/amazon/ionelement/api/AnyElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/SymbolElement : com/amazon/ionelement/api/TextElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/SymbolElement;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/SymbolElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/SymbolElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/SymbolElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/SymbolElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/SymbolElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/SymbolElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/TextElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/TextElement;
+	public abstract fun getTextValue ()Ljava/lang/String;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/TextElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/TextElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/TextElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/TextElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/TextElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/TextElement;
+}
+
+public abstract interface class com/amazon/ionelement/api/TimestampElement : com/amazon/ionelement/api/IonElement {
+	public abstract fun copy (Ljava/util/List;Ljava/util/Map;)Lcom/amazon/ionelement/api/TimestampElement;
+	public abstract fun getTimestampValue ()Lcom/amazon/ion/Timestamp;
+	public abstract fun withAnnotations (Ljava/lang/Iterable;)Lcom/amazon/ionelement/api/TimestampElement;
+	public abstract fun withAnnotations ([Ljava/lang/String;)Lcom/amazon/ionelement/api/TimestampElement;
+	public abstract fun withMeta (Ljava/lang/String;Ljava/lang/Object;)Lcom/amazon/ionelement/api/TimestampElement;
+	public abstract fun withMetas (Ljava/util/Map;)Lcom/amazon/ionelement/api/TimestampElement;
+	public abstract fun withoutAnnotations ()Lcom/amazon/ionelement/api/TimestampElement;
+	public abstract fun withoutMetas ()Lcom/amazon/ionelement/api/TimestampElement;
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id 'signing'
     id 'org.jetbrains.dokka' version '0.9.18'
     id 'jacoco'
+    id 'org.jetbrains.kotlinx.binary-compatibility-validator' version '0.9.0'
 }
 
 group = "com.amazon.ion"

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ plugins {
     id 'org.jetbrains.dokka' version '0.9.18'
     id 'jacoco'
     id 'org.jetbrains.kotlinx.binary-compatibility-validator' version '0.9.0'
+    id "org.jlleitschuh.gradle.ktlint" version "10.3.0"
 }
 
 group = "com.amazon.ion"
@@ -103,6 +104,10 @@ tasks.jacocoTestReport {
     dependsOn(tasks.test) // tests are required to run before generating the report
 }
 
+ktlint {
+    version = "0.45.2"
+    outputToConsole = true
+}
 
 plugins.withId('org.jetbrains.kotlin.jvm', { _ ->
     sourceSets {

--- a/src/com/amazon/ionelement/api/ByteArrayView.kt
+++ b/src/com/amazon/ionelement/api/ByteArrayView.kt
@@ -22,4 +22,3 @@ public interface ByteArrayView : Iterable<Byte> {
 
     public fun copyOfBytes(): ByteArray
 }
-

--- a/src/com/amazon/ionelement/api/ElementType.kt
+++ b/src/com/amazon/ionelement/api/ElementType.kt
@@ -42,7 +42,7 @@ public enum class ElementType(
     BOOL(false, false, false, false),
     INT(false, false, false, false),
     FLOAT(false, false, false, false),
-    DECIMAL(false, false, false,false),
+    DECIMAL(false, false, false, false),
     TIMESTAMP(false, false, false, false),
 
     // String-valued types
@@ -60,7 +60,7 @@ public enum class ElementType(
     STRUCT(false, true, false, false);
 
     /** Converts this [ElementType] to [IonType]. */
-    public fun toIonType(): IonType = when(this) {
+    public fun toIonType(): IonType = when (this) {
         NULL -> IonType.NULL
         BOOL -> IonType.BOOL
         INT -> IonType.INT
@@ -83,7 +83,7 @@ public enum class ElementType(
  * @throws [IllegalStateException] if the receiver is [IonType.DATAGRAM] because [AnyElement] has no notion of
  * datagrams.
  */
-public fun IonType.toElementType(): ElementType = when(this) {
+public fun IonType.toElementType(): ElementType = when (this) {
     IonType.NULL -> ElementType.NULL
     IonType.BOOL -> ElementType.BOOL
     IonType.INT -> ElementType.INT

--- a/src/com/amazon/ionelement/api/Ion.kt
+++ b/src/com/amazon/ionelement/api/Ion.kt
@@ -13,7 +13,6 @@
  *  permissions and limitations under the License.
  */
 
-
 @file: JvmName("Ion")
 package com.amazon.ionelement.api
 
@@ -34,9 +33,8 @@ import com.amazon.ionelement.impl.StructElementImpl
 import com.amazon.ionelement.impl.StructFieldImpl
 import com.amazon.ionelement.impl.SymbolElementImpl
 import com.amazon.ionelement.impl.TimestampElementImpl
-import kotlinx.collections.immutable.PersistentList
 import java.math.BigInteger
-
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
@@ -117,7 +115,6 @@ public fun ionNull(
     elementType: ElementType = ElementType.NULL,
     metas: MetaContainer
 ): IonElement = ionNull(elementType, emptyList(), metas)
-
 
 /** Creates a [StringElement] that represents an Ion `symbol`. */
 @JvmOverloads

--- a/src/com/amazon/ionelement/api/IonElement.kt
+++ b/src/com/amazon/ionelement/api/IonElement.kt
@@ -153,7 +153,6 @@ public interface TimestampElement : IonElement {
     override fun withoutMetas(): TimestampElement
 }
 
-
 /** Indicates the size of the integer element. */
 public enum class IntElementSize {
     /** For integer values representable by a [Long]. */
@@ -266,7 +265,7 @@ public interface SymbolElement : TextElement {
 
 /** Represents an Ion clob or blob. */
 public interface LobElement : IonElement {
-    public val bytesValue:  ByteArrayView
+    public val bytesValue: ByteArrayView
     override fun copy(annotations: List<String>, metas: MetaContainer): LobElement
 
     override fun withAnnotations(vararg additionalAnnotations: String): LobElement
@@ -437,7 +436,6 @@ public interface StructElement : ContainerElement {
 
     /** The same as [get] but returns a null reference if the field does not exist.  */
     public fun getOptional(fieldName: String): AnyElement?
-
 
     /** Retrieves all values with a given field name. Returns an empty iterable if the field does not exist. */
     public fun getAll(fieldName: String): Iterable<AnyElement>

--- a/src/com/amazon/ionelement/api/IonElementExtensions.kt
+++ b/src/com/amazon/ionelement/api/IonElementExtensions.kt
@@ -16,19 +16,18 @@
 package com.amazon.ionelement.api
 
 /** Returns a shallow copy of the current node with the specified additional annotations. */
-internal inline fun <reified T: IonElement> T._withAnnotations(vararg additionalAnnotations: String): T =
+internal inline fun <reified T : IonElement> T._withAnnotations(vararg additionalAnnotations: String): T =
     when {
         additionalAnnotations.isEmpty() -> this
         else -> copy(annotations = this.annotations + additionalAnnotations) as T
     }
 
-
 /** Returns a shallow copy of the current node with the specified additional annotations. */
-internal inline fun <reified T: IonElement> T._withAnnotations(additionalAnnotations: Iterable<String>): T =
+internal inline fun <reified T : IonElement> T._withAnnotations(additionalAnnotations: Iterable<String>): T =
     _withAnnotations(*additionalAnnotations.toList().toTypedArray())
 
 /** Returns a shallow copy of the current node with all annotations removed. */
-internal inline fun <reified T: IonElement> T._withoutAnnotations(): T =
+internal inline fun <reified T : IonElement> T._withoutAnnotations(): T =
     when {
         this.annotations.isNotEmpty() -> copy(annotations = emptyList()) as T
         else -> this
@@ -38,7 +37,7 @@ internal inline fun <reified T: IonElement> T._withoutAnnotations(): T =
  * Returns a shallow copy of the current node with the specified additional metadata, overwriting any metas
  * that already exist with the same keys.
  */
-internal inline fun <reified T: IonElement> T._withMetas(additionalMetas: MetaContainer): T =
+internal inline fun <reified T : IonElement> T._withMetas(additionalMetas: MetaContainer): T =
     when {
         additionalMetas.isEmpty() -> this
         else -> copy(metas = metaContainerOf(metas.toList().union(additionalMetas.toList()).toList())) as T
@@ -50,11 +49,11 @@ internal inline fun <reified T: IonElement> T._withMetas(additionalMetas: MetaCo
  *
  * When adding multiple metas, consider [withMetas] instead.
  */
-internal inline fun <reified T: IonElement> T._withMeta(key: String, value: Any): T =
+internal inline fun <reified T : IonElement> T._withMeta(key: String, value: Any): T =
     _withMetas(metaContainerOf(key to value))
 
 /** Returns a shallow copy of the current node without any metadata. */
-internal inline fun <reified T: IonElement> T._withoutMetas(): T =
+internal inline fun <reified T : IonElement> T._withoutMetas(): T =
     when {
         metas.isEmpty() -> this
         else -> copy(metas = emptyMetaContainer(), annotations = annotations) as T
@@ -84,7 +83,7 @@ public val SeqElement.head: AnyElement
  *
  * If this container has no elements, throws [IonElementException].
  */
-public val SeqElement.tail: List<AnyElement> get()  =
+public val SeqElement.tail: List<AnyElement> get() =
     when (this.size) {
         0 -> constraintError(this, "Cannot get tail of empty container")
         else -> this.values.subList(1, this.size)

--- a/src/com/amazon/ionelement/api/IonLocation.kt
+++ b/src/com/amazon/ionelement/api/IonLocation.kt
@@ -23,7 +23,7 @@ public data class IonTextLocation(val line: Long, val charOffset: Long) : IonLoc
     override fun toString(): String = "$line:$charOffset"
 }
 
-public data class IonBinaryLocation(val byteOffset: Long): IonLocation() {
+public data class IonBinaryLocation(val byteOffset: Long) : IonLocation() {
     override fun toString(): String = byteOffset.toString()
 }
 

--- a/src/com/amazon/ionelement/api/IonMeta.kt
+++ b/src/com/amazon/ionelement/api/IonMeta.kt
@@ -30,7 +30,6 @@ public inline fun <reified T> MetaContainer.metaOrNull(key: String): T? = this[k
 public inline fun <reified T> MetaContainer.meta(key: String): T =
     metaOrNull(key) ?: error("Meta with key '$key' and type ${T::class.java} not found in MetaContainer")
 
-
 public fun metaContainerOf(kvps: List<Pair<String, Any>>): MetaContainer =
     metaContainerOf(*kvps.toTypedArray())
 
@@ -53,4 +52,3 @@ public operator fun MetaContainer.plus(other: MetaContainer): MetaContainer =
  */
 public operator fun MetaContainer.plus(other: Iterable<Pair<String, Any>>): MetaContainer =
     HashMap<String, Any>(this.toList().union(other).toMap())
-

--- a/src/com/amazon/ionelement/api/IonUtils.kt
+++ b/src/com/amazon/ionelement/api/IonUtils.kt
@@ -44,7 +44,7 @@ public fun IonElement.toIonValue(factory: ValueFactory): IonValue {
  * New code that does not need to integrate with uses of the mutable DOM should not use this.
  */
 public fun IonValue.toIonElement(): AnyElement =
-    this.system.newReader(this).use { reader->
+    this.system.newReader(this).use { reader ->
         createIonElementLoader().loadSingleElement(reader)
     }
 

--- a/src/com/amazon/ionelement/api/StructField.kt
+++ b/src/com/amazon/ionelement/api/StructField.kt
@@ -25,4 +25,3 @@ public interface StructField {
     public operator fun component1(): String
     public operator fun component2(): AnyElement
 }
-

--- a/src/com/amazon/ionelement/impl/AnyElementBase.kt
+++ b/src/com/amazon/ionelement/impl/AnyElementBase.kt
@@ -16,13 +16,13 @@
 package com.amazon.ionelement.impl
 
 import com.amazon.ion.Decimal
-import com.amazon.ion.IntegerSize
 import com.amazon.ion.IonWriter
 import com.amazon.ion.Timestamp
 import com.amazon.ion.system.IonTextWriterBuilder
 import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.BlobElement
 import com.amazon.ionelement.api.BoolElement
+import com.amazon.ionelement.api.ByteArrayView
 import com.amazon.ionelement.api.ClobElement
 import com.amazon.ionelement.api.ContainerElement
 import com.amazon.ionelement.api.DecimalElement
@@ -42,16 +42,15 @@ import com.amazon.ionelement.api.ElementType.SYMBOL
 import com.amazon.ionelement.api.ElementType.TIMESTAMP
 import com.amazon.ionelement.api.FloatElement
 import com.amazon.ionelement.api.IntElement
-import com.amazon.ionelement.api.ByteArrayView
 import com.amazon.ionelement.api.IntElementSize
 import com.amazon.ionelement.api.IonElement
-import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.ListElement
 import com.amazon.ionelement.api.LobElement
 import com.amazon.ionelement.api.SeqElement
 import com.amazon.ionelement.api.SexpElement
 import com.amazon.ionelement.api.StringElement
 import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.SymbolElement
 import com.amazon.ionelement.api.TextElement
 import com.amazon.ionelement.api.TimestampElement
@@ -74,7 +73,7 @@ internal abstract class AnyElementBase : AnyElement {
     protected abstract fun writeContentTo(writer: IonWriter)
 
     override fun writeTo(writer: IonWriter) {
-        if(this.annotations.any()) {
+        if (this.annotations.any()) {
             writer.setTypeAnnotations(*this.annotations.toTypedArray())
         }
         this.writeContentTo(writer)
@@ -86,12 +85,12 @@ internal abstract class AnyElementBase : AnyElement {
 
     override val integerSize: IntElementSize get() = constraintError(this, "integerSize not valid for this Element")
 
-    private inline fun <reified T: IonElement> requireTypeAndCastOrNull(allowedType: ElementType): T? {
-        if(this.type == NULL) {
+    private inline fun <reified T : IonElement> requireTypeAndCastOrNull(allowedType: ElementType): T? {
+        if (this.type == NULL) {
             return null
         }
 
-        if(this.type != allowedType)
+        if (this.type != allowedType)
             errIfNotTyped(allowedType)
 
         return when {
@@ -105,20 +104,20 @@ internal abstract class AnyElementBase : AnyElement {
         constraintError(this, "Expected an element of type $allowedType but found an element of type ${this.type}")
     }
 
-    private fun errIfNotTyped(allowedType: ElementType, allowedType2: ElementType): Nothing  {
+    private fun errIfNotTyped(allowedType: ElementType, allowedType2: ElementType): Nothing {
         constraintError(this, "Expected an element of type $allowedType or $allowedType2 but found an element of type ${this.type}")
     }
 
-    private fun errIfNotTyped(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): Nothing  {
+    private fun errIfNotTyped(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): Nothing {
         constraintError(this, "Expected an element of type $allowedType, $allowedType2 or $allowedType3 but found an element of type ${this.type}")
     }
 
-    private inline fun <reified T: IonElement> requireTypeAndCastOrNull(allowedType: ElementType, allowedType2: ElementType): T? {
-        if(this.type == NULL) {
+    private inline fun <reified T : IonElement> requireTypeAndCastOrNull(allowedType: ElementType, allowedType2: ElementType): T? {
+        if (this.type == NULL) {
             return null
         }
 
-        if(this.type != allowedType && this.type != allowedType2)
+        if (this.type != allowedType && this.type != allowedType2)
             errIfNotTyped(allowedType, allowedType2)
 
         return when {
@@ -128,12 +127,12 @@ internal abstract class AnyElementBase : AnyElement {
         }
     }
 
-    private inline fun <reified T: IonElement> requireTypeAndCastOrNull(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): T? {
-        if(this.type == NULL) {
+    private inline fun <reified T : IonElement> requireTypeAndCastOrNull(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): T? {
+        if (this.type == NULL) {
             return null
         }
 
-        if(this.type != allowedType && this.type != allowedType2 && this.type != allowedType3)
+        if (this.type != allowedType && this.type != allowedType2 && this.type != allowedType3)
             constraintError(this, "Expected an element of type $allowedType, $allowedType2 or $allowedType3 but found an element of type ${this.type}")
 
         return when {
@@ -143,17 +142,17 @@ internal abstract class AnyElementBase : AnyElement {
         }
     }
 
-    private inline fun <reified T: IonElement> requireTypeAndCast(allowedType: ElementType): T {
+    private inline fun <reified T : IonElement> requireTypeAndCast(allowedType: ElementType): T {
         requireTypeAndCastOrNull<T>(allowedType) ?: constraintError(this, "Required non-null value of type $allowedType but found a $this")
         return this as T
     }
 
-    private inline fun <reified T: IonElement> requireTypeAndCast(allowedType: ElementType, allowedType2: ElementType): T {
+    private inline fun <reified T : IonElement> requireTypeAndCast(allowedType: ElementType, allowedType2: ElementType): T {
         requireTypeAndCastOrNull<T>(allowedType, allowedType2) ?: constraintError(this, "Required non-null value of type $allowedType or $allowedType2 but found a $this")
         return this as T
     }
 
-    private inline fun <reified T: IonElement> requireTypeAndCast(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): T {
+    private inline fun <reified T : IonElement> requireTypeAndCast(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): T {
         requireTypeAndCastOrNull<T>(allowedType, allowedType2, allowedType3) ?: constraintError(this, "Required non-null value of type $allowedType, $allowedType2 or $allowedType3 but found a $this")
         return this as T
     }
@@ -175,7 +174,7 @@ internal abstract class AnyElementBase : AnyElement {
     final override fun asSymbolOrNull(): SymbolElement? = requireTypeAndCastOrNull(SYMBOL)
     final override fun asTimestamp(): TimestampElement = requireTypeAndCast(TIMESTAMP)
     final override fun asTimestampOrNull(): TimestampElement? = requireTypeAndCastOrNull(TIMESTAMP)
-    final override fun asLob(): LobElement  = requireTypeAndCast(BLOB, CLOB)
+    final override fun asLob(): LobElement = requireTypeAndCast(BLOB, CLOB)
     final override fun asLobOrNull(): LobElement? = requireTypeAndCastOrNull(BLOB, CLOB)
     final override fun asBlob(): BlobElement = requireTypeAndCast(BLOB)
     final override fun asBlobOrNull(): BlobElement? = requireTypeAndCastOrNull(BLOB)
@@ -214,7 +213,7 @@ internal abstract class AnyElementBase : AnyElement {
 
     // Default implementations that perform the type check and wrap the corresponding non-nullable version.
     final override val booleanValueOrNull: Boolean? get() = requireTypeAndCastOrNull<BoolElement>(BOOL)?.booleanValue
-    final override val longValueOrNull: Long? get() =  requireTypeAndCastOrNull<IntElement>(INT)?.longValue
+    final override val longValueOrNull: Long? get() = requireTypeAndCastOrNull<IntElement>(INT)?.longValue
     final override val bigIntegerValueOrNull: BigInteger? get() = requireTypeAndCastOrNull<IntElement>(INT)?.bigIntegerValue
     final override val textValueOrNull: String? get() = requireTypeAndCastOrNull<TextElement>(STRING, SYMBOL)?.textValue
     final override val stringValueOrNull: String? get() = requireTypeAndCastOrNull<StringElement>(STRING)?.textValue
@@ -231,4 +230,3 @@ internal abstract class AnyElementBase : AnyElement {
     final override val sexpValuesOrNull: List<AnyElement>? get() = requireTypeAndCastOrNull<SexpElement>(SEXP)?.values
     final override val structFieldsOrNull: Collection<StructField>? get() = requireTypeAndCastOrNull<StructElement>(STRUCT)?.fields
 }
-

--- a/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BigIntIntElementImpl.kt
@@ -15,15 +15,14 @@
 
 package com.amazon.ionelement.impl
 
-import com.amazon.ion.IntegerSize
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
 import com.amazon.ionelement.api.constraintError
+import java.math.BigInteger
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
-import java.math.BigInteger
 
 internal class BigIntIntElementImpl(
     override val bigIntegerValue: BigInteger,
@@ -36,7 +35,7 @@ internal class BigIntIntElementImpl(
     override val integerSize: IntElementSize get() = IntElementSize.BIG_INTEGER
 
     override val longValue: Long get() {
-        if(bigIntegerValue > MAX_LONG_AS_BIG_INT || bigIntegerValue < MIN_LONG_AS_BIG_INT) {
+        if (bigIntegerValue > MAX_LONG_AS_BIG_INT || bigIntegerValue < MIN_LONG_AS_BIG_INT) {
             constraintError(this, "Ion integer value outside of range of 64 bit signed integer, use bigIntegerValue instead.")
         }
         return bigIntegerValue.longValueExact()
@@ -77,4 +76,3 @@ internal class BigIntIntElementImpl(
 
 internal val MAX_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MAX_VALUE)
 internal val MIN_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MIN_VALUE)
-

--- a/src/com/amazon/ionelement/impl/BlobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BlobElementImpl.kt
@@ -18,7 +18,6 @@ package com.amazon.ionelement.impl
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap

--- a/src/com/amazon/ionelement/impl/BoolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/BoolElementImpl.kt
@@ -26,7 +26,7 @@ internal class BoolElementImpl(
     override val booleanValue: Boolean,
     override val annotations: PersistentList<String>,
     override val metas: PersistentMetaContainer
-): AnyElementBase(), BoolElement {
+) : AnyElementBase(), BoolElement {
     override val type: ElementType get() = ElementType.BOOL
 
     override fun copy(annotations: List<String>, metas: MetaContainer): BoolElementImpl =
@@ -38,7 +38,7 @@ internal class BoolElementImpl(
     override fun withMetas(additionalMetas: MetaContainer): BoolElementImpl = _withMetas(additionalMetas)
     override fun withMeta(key: String, value: Any): BoolElementImpl = _withMeta(key, value)
     override fun withoutMetas(): BoolElementImpl = _withoutMetas()
-    
+
     override fun writeContentTo(writer: IonWriter) = writer.writeBool(booleanValue)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -59,5 +59,4 @@ internal class BoolElementImpl(
         // Note: metas intentionally omitted!
         return result
     }
-
 }

--- a/src/com/amazon/ionelement/impl/ByteArrayViewImpl.kt
+++ b/src/com/amazon/ionelement/impl/ByteArrayViewImpl.kt
@@ -23,5 +23,4 @@ internal class ByteArrayViewImpl(private val bytes: ByteArray) : ByteArrayView {
     override fun hashCode(): Int {
         return bytes.contentHashCode()
     }
-
 }

--- a/src/com/amazon/ionelement/impl/ClobElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ClobElementImpl.kt
@@ -18,7 +18,6 @@ package com.amazon.ionelement.impl
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap

--- a/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/DecimalElementImpl.kt
@@ -19,7 +19,6 @@ import com.amazon.ion.Decimal
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap

--- a/src/com/amazon/ionelement/impl/FloatElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/FloatElementImpl.kt
@@ -18,7 +18,6 @@ package com.amazon.ionelement.impl
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
-
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -62,5 +61,4 @@ internal class FloatElementImpl(
         // Note: metas intentionally omitted!
         return result
     }
-
 }

--- a/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/com/amazon/ionelement/impl/IonElementLoaderImpl.kt
@@ -35,11 +35,12 @@ internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions
     private inline fun <T> handleReaderException(ionReader: IonReader, crossinline block: () -> T): T {
         try {
             return block()
-        } catch(e: IonException) {
+        } catch (e: IonException) {
             throw IonElementException(
                 location = ionReader.currentLocation(),
                 description = "IonException occurred, likely due to malformed Ion data (see cause)",
-                cause = e)
+                cause = e
+            )
         }
     }
 
@@ -181,7 +182,7 @@ internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions
  * Calls [IonReader.next] and invokes [block] until all values at the current level in the [IonReader]
  * have been exhausted.
  * */
-private fun <T> IonReader.forEachValue(block: () -> T): Unit {
+private fun <T> IonReader.forEachValue(block: () -> T) {
     while (this.next() != null) {
         block()
     }

--- a/src/com/amazon/ionelement/impl/ListElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/ListElementImpl.kt
@@ -21,11 +21,11 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
-internal class ListElementImpl (
+internal class ListElementImpl(
     values: PersistentList<AnyElement>,
     override val annotations: PersistentList<String>,
     override val metas: PersistentMetaContainer
-): SeqElementBase(values), ListElement {
+) : SeqElementBase(values), ListElement {
     override val type: ElementType get() = ElementType.LIST
 
     override val listValues: List<AnyElement> get() = values

--- a/src/com/amazon/ionelement/impl/LobElementBase.kt
+++ b/src/com/amazon/ionelement/impl/LobElementBase.kt
@@ -21,7 +21,7 @@ import com.amazon.ionelement.api.MetaContainer
 
 internal abstract class LobElementBase(
     protected val bytes: ByteArray
-): AnyElementBase(), LobElement {
+) : AnyElementBase(), LobElement {
 
     override val bytesValue: ByteArrayView = ByteArrayViewImpl(bytes)
 
@@ -52,6 +52,4 @@ internal abstract class LobElementBase(
         // Metas are intentionally omitted here.
         return result
     }
-
 }
-

--- a/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/LongIntElementImpl.kt
@@ -18,10 +18,10 @@ package com.amazon.ionelement.impl
 import com.amazon.ion.IonWriter
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.api.PersistentMetaContainer
+import java.math.BigInteger
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
-import java.math.BigInteger
 
 internal class LongIntElementImpl(
     override val longValue: Long,
@@ -64,4 +64,3 @@ internal class LongIntElementImpl(
         return result
     }
 }
-

--- a/src/com/amazon/ionelement/impl/NullElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/NullElementImpl.kt
@@ -26,7 +26,7 @@ internal class NullElementImpl(
     override val type: ElementType = ElementType.NULL,
     override val annotations: PersistentList<String>,
     override val metas: PersistentMetaContainer
-): AnyElementBase() {
+) : AnyElementBase() {
 
     override val isNull: Boolean get() = true
 

--- a/src/com/amazon/ionelement/impl/SeqElementBase.kt
+++ b/src/com/amazon/ionelement/impl/SeqElementBase.kt
@@ -23,7 +23,7 @@ import kotlinx.collections.immutable.PersistentList
 
 internal abstract class SeqElementBase(
     override val values: PersistentList<AnyElement>
-): AnyElementBase(), SeqElement {
+) : AnyElementBase(), SeqElement {
 
     override val containerValues: List<AnyElement> get() = values
     override val seqValues: List<AnyElement> get() = values
@@ -47,5 +47,3 @@ internal abstract class SeqElementBase(
     abstract override fun withMeta(key: String, value: Any): SeqElementBase
     abstract override fun withoutMetas(): SeqElementBase
 }
-
-

--- a/src/com/amazon/ionelement/impl/SexpElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SexpElementImpl.kt
@@ -21,11 +21,11 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 
-internal class SexpElementImpl (
+internal class SexpElementImpl(
     values: PersistentList<AnyElement>,
     override val annotations: PersistentList<String>,
     override val metas: PersistentMetaContainer
-):  SeqElementBase(values), SexpElement {
+) : SeqElementBase(values), SexpElement {
     override val type: ElementType get() = ElementType.SEXP
 
     override val sexpValues: List<AnyElement> get() = seqValues

--- a/src/com/amazon/ionelement/impl/StringElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StringElementImpl.kt
@@ -26,7 +26,7 @@ internal class StringElementImpl(
     value: String,
     override val annotations: PersistentList<String>,
     override val metas: PersistentMetaContainer
-): TextElementBase(value), StringElement {
+) : TextElementBase(value), StringElement {
     override val type: ElementType get() = ElementType.STRING
 
     override val stringValue: String get() = textValue

--- a/src/com/amazon/ionelement/impl/StructElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/StructElementImpl.kt
@@ -30,7 +30,7 @@ internal class StructElementImpl(
     private val allFields: PersistentList<StructField>,
     override val annotations: PersistentList<String>,
     override val metas: PersistentMetaContainer
-): AnyElementBase(), StructElement {
+) : AnyElementBase(), StructElement {
 
     override val type: ElementType get() = ElementType.STRUCT
     override val size = allFields.size
@@ -40,15 +40,14 @@ internal class StructElementImpl(
     private var valuesBackingField: PersistentCollection<AnyElement>? = null
     override val values: Collection<AnyElement>
         get() {
-            if(valuesBackingField == null) {
+            if (valuesBackingField == null) {
                 valuesBackingField = fields.map { it.value }.toPersistentList()
             }
             return valuesBackingField!!
-    }
+        }
     override val containerValues: Collection<AnyElement> get() = values
     override val structFields: Collection<StructField> get() = allFields
     override val fields: Collection<StructField> get() = allFields
-
 
     // Note that we are not using `by lazy` here because it requires 2 additional allocations and
     // has been demonstrated to significantly increase memory consumption!
@@ -57,7 +56,7 @@ internal class StructElementImpl(
     /** Lazily calculated map of field names and lists of their values. */
     private val fieldsByName: Map<String, List<AnyElement>>
         get() {
-            if(fieldsByNameBackingField == null) {
+            if (fieldsByNameBackingField == null) {
                 fieldsByNameBackingField =
                     fields
                         .groupBy { it.name }
@@ -106,7 +105,7 @@ internal class StructElementImpl(
         if (this.fieldsByName.size != other.fieldsByName.size) return false
 
         // If we make it this far we can compare the list of field names in both
-        if(this.fieldsByName.keys != other.fieldsByName.keys) return false
+        if (this.fieldsByName.keys != other.fieldsByName.keys) return false
 
         // If we make it this far then we have to take the expensive approach of comparing the individual values in
         // [this] and [other].
@@ -120,12 +119,12 @@ internal class StructElementImpl(
 
             // [otherGroup] should never be null due to the `if` statement above.
             val otherGroup = other.fieldsByName[thisFieldGroup.key]
-                             ?: error("unexpectedly missing other field named '${thisFieldGroup.key}'")
+                ?: error("unexpectedly missing other field named '${thisFieldGroup.key}'")
 
             val otherSubGroup: Map<AnyElement, Int> = otherGroup.groupingBy { it }.eachCount()
 
             // Simple equality should work from here
-            if(thisSubGroup != otherSubGroup) {
+            if (thisSubGroup != otherSubGroup) {
                 return false
             }
         }

--- a/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/SymbolElementImpl.kt
@@ -26,7 +26,7 @@ internal class SymbolElementImpl(
     value: String,
     override val annotations: PersistentList<String>,
     override val metas: PersistentMetaContainer
-): TextElementBase(value), SymbolElement {
+) : TextElementBase(value), SymbolElement {
     override val type: ElementType get() = ElementType.SYMBOL
 
     override val symbolValue: String get() = textValue

--- a/src/com/amazon/ionelement/impl/TextElementBase.kt
+++ b/src/com/amazon/ionelement/impl/TextElementBase.kt
@@ -20,7 +20,7 @@ import com.amazon.ionelement.api.TextElement
 
 internal abstract class TextElementBase(
     override val textValue: String
-): AnyElementBase(), TextElement {
+) : AnyElementBase(), TextElement {
 
     abstract override fun copy(annotations: List<String>, metas: MetaContainer): TextElementBase
     abstract override fun withAnnotations(vararg additionalAnnotations: String): TextElementBase
@@ -30,4 +30,3 @@ internal abstract class TextElementBase(
     abstract override fun withMeta(key: String, value: Any): TextElementBase
     abstract override fun withoutMetas(): TextElementBase
 }
-

--- a/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
+++ b/src/com/amazon/ionelement/impl/TimestampElementImpl.kt
@@ -27,7 +27,7 @@ internal class TimestampElementImpl(
     override val timestampValue: Timestamp,
     override val annotations: PersistentList<String>,
     override val metas: PersistentMetaContainer
-): AnyElementBase(), TimestampElement {
+) : AnyElementBase(), TimestampElement {
 
     override val type: ElementType get() = ElementType.TIMESTAMP
     override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElementImpl =

--- a/test/com/amazon/ionelement/AnyElementTests.kt
+++ b/test/com/amazon/ionelement/AnyElementTests.kt
@@ -35,13 +35,13 @@ import com.amazon.ionelement.api.IonElementException
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.loadSingleElement
 import com.amazon.ionelement.impl.ByteArrayViewImpl
+import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import java.math.BigInteger
 
 class AnyElementTests {
     @ParameterizedTest
@@ -56,8 +56,8 @@ class AnyElementTests {
         /** Test what we were unable to in [assertAccessors] */
         val s = loadSingleElement("{ foo: 1, bar: 2 }").structFields
         assertEquals(2, s.count())
-        s.single { it.name == "foo" && it.value.longValue == 1L}
-        s.single { it.name == "bar" && it.value.longValue == 2L}
+        s.single { it.name == "foo" && it.value.longValue == 1L }
+        s.single { it.name == "bar" && it.value.longValue == 2L }
     }
 
     @Test
@@ -107,7 +107,8 @@ class AnyElementTests {
             TestCase("[1]", LIST, listOf(ionInt(1))),
             TestCase("(2)", SEXP, listOf(ionInt(2))),
             // Note, this test case only checks `.containerValues`
-            TestCase("{ foo: 42 }", STRUCT, listOf(ionInt(42))))
+            TestCase("{ foo: 42 }", STRUCT, listOf(ionInt(42)))
+        )
 
         private fun assertElementProperties(element: AnyElement, elementType: ElementType, expectedValue: Any?) {
             assertEquals(elementType, element.type)
@@ -372,7 +373,7 @@ class AnyElementTests {
          */
         private fun assertThrowsForWrongAccessorTypes(element: AnyElement) {
             with(element) {
-                if(type == NULL) {
+                if (type == NULL) {
                     // No checks needed in this case because:
                     // - Non-null accessors will throw for due to the value being unexpectedly null. (checked in [assertAccessors]).
                     // - *OrNull accessors never throw in this case.
@@ -493,6 +494,5 @@ class AnyElementTests {
                 }
             }
         }
-
     }
 }

--- a/test/com/amazon/ionelement/ComplianceTests.kt
+++ b/test/com/amazon/ionelement/ComplianceTests.kt
@@ -22,10 +22,6 @@ import com.amazon.ion.system.IonTextWriterBuilder
 import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.loadAllElements
 import com.amazon.ionelement.util.INCLUDE_LOCATION_META
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -35,6 +31,10 @@ import java.nio.file.Paths
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.function.BiPredicate
 import java.util.stream.Stream
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 val TESTS_ROOT_DIR = "./ion-tests/iontestdata"
 val GOOD_DIR: Path = Paths.get(TESTS_ROOT_DIR, "good")
@@ -73,12 +73,11 @@ class ComplianceTests {
         private fun findTestFiles(rootDir: Path): Stream<Path> {
             val searchPredicate = BiPredicate<Path, BasicFileAttributes> { path, _ ->
                 val pathStr = path.toString()
-                (pathStr.endsWith(".ion") || pathStr.endsWith(".10n"))
-                && !SKIP_LIST.contains(pathStr)
+                (pathStr.endsWith(".ion") || pathStr.endsWith(".10n")) &&
+                    !SKIP_LIST.contains(pathStr)
             }
             return Files.find(rootDir, 100, searchPredicate)
         }
-
     }
 
     @ParameterizedTest
@@ -111,7 +110,7 @@ class ComplianceTests {
 
         // Every top level value is a list or s-exp value containing values that should be equivalent
         topLevelValues.forEach { equivalenceGroup ->
-            if(equivalenceGroup.annotations.contains("embedded_documents")) {
+            if (equivalenceGroup.annotations.contains("embedded_documents")) {
                 val documents = equivalenceGroup.asSeqOrNull()?.values?.map {
                     loadAllElements(it.stringValue, INCLUDE_LOCATION_META).toList()
                 } ?: error("Unexpected null encountered")
@@ -147,7 +146,7 @@ class ComplianceTests {
 
         immutableIonValues.forEachIndexed { i, iIndex ->
             immutableIonValues.forEachIndexed { n, nIndex ->
-                if(iIndex != nIndex) {
+                if (iIndex != nIndex) {
                     assertNotEquals(i, n, "$i and $n must *not* be equivalent")
                 }
             }
@@ -189,6 +188,4 @@ class ComplianceTests {
                 String(stream.toByteArray())
             }
         }
-
-
 }

--- a/test/com/amazon/ionelement/ConstructorTests.kt
+++ b/test/com/amazon/ionelement/ConstructorTests.kt
@@ -21,12 +21,12 @@ import com.amazon.ionelement.api.ionStructOf
 import com.amazon.ionelement.api.ionSymbol
 import com.amazon.ionelement.api.ionTimestamp
 import com.amazon.ionelement.api.metaContainerOf
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 class ConstructorTests {
 
@@ -49,7 +49,7 @@ class ConstructorTests {
             ionSymbol("foo", dummyAnnotations, dummyMetas),
             ionClob(ByteArray(1), dummyAnnotations, dummyMetas),
             ionBlob(ByteArray(1), dummyAnnotations, dummyMetas),
-            ionListOf(ionInt(1), annotations =  dummyAnnotations, metas = dummyMetas),
+            ionListOf(ionInt(1), annotations = dummyAnnotations, metas = dummyMetas),
             ionListOf(listOf(ionInt(1)), dummyAnnotations, dummyMetas),
             ionSexpOf(ionInt(1), annotations = dummyAnnotations, metas = dummyMetas),
             ionSexpOf(listOf(ionInt(1)), dummyAnnotations, dummyMetas),
@@ -104,7 +104,7 @@ class ConstructorTests {
         assertEquals(1, elem.metas.size)
         assertEquals(1, elem.metas["foo_meta"])
     }
-    
+
     @Test
     fun scalarConstructorsValueTest() {
         assertTrue(ionNull(ElementType.NULL).isNull)
@@ -163,5 +163,4 @@ class ConstructorTests {
         assertEquals(1, struct.size)
         assertEquals(12L, struct["foo"].longValue)
     }
-
 }

--- a/test/com/amazon/ionelement/EquivTestCase.kt
+++ b/test/com/amazon/ionelement/EquivTestCase.kt
@@ -15,8 +15,8 @@
 
 package com.amazon.ionelement
 
-import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.AnyElement
+import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.createIonElementLoader
 import com.amazon.ionelement.api.ionStructOf
 import org.junit.jupiter.api.Assertions
@@ -51,7 +51,8 @@ data class EquivTestCase(val left: String, val right: String, val isEquiv: Boole
         checkEquivalence(
             isEquiv,
             leftElementWithAnnotation,
-            rightElementWithAnnotation)
+            rightElementWithAnnotation
+        )
 
         // Adding an annotation to only one side will force them to be not equivalent
         checkEquivalence(false, leftElement.withAnnotations("some_annotation"), rightElement)

--- a/test/com/amazon/ionelement/EquivalenceTests.kt
+++ b/test/com/amazon/ionelement/EquivalenceTests.kt
@@ -15,6 +15,9 @@
 
 package com.amazon.ionelement
 
+import com.amazon.ion.Decimal
+import com.amazon.ion.Timestamp
+import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.emptyBlob
 import com.amazon.ionelement.api.emptyClob
 import com.amazon.ionelement.api.emptyIonList
@@ -31,14 +34,10 @@ import com.amazon.ionelement.api.ionTimestamp
 import com.amazon.ionelement.util.ArgumentsProviderBase
 import com.amazon.ionelement.util.randomIonElement
 import com.amazon.ionelement.util.randomSeed
-import com.amazon.ion.Decimal
-import com.amazon.ion.Timestamp
-import com.amazon.ionelement.api.ElementType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
-
 
 private val ALL_NULLS = ElementType.values().map { ionNull(it) }
 
@@ -61,7 +60,6 @@ private fun List<EquivTestCase>.includeAnnotations(): List<EquivTestCase> {
 
     return this + sameAnnotationBothSides + differentAnnotationEachSide + annotationAddedOnlyToOneSide
 }
-
 
 /**
  * The goal of this test class is to validate the result of `equals` and `hashCode` for all implementations
@@ -117,7 +115,8 @@ class EquivalenceTests {
                     EquivTestCase(
                         left = nullValue.toString(),
                         right = nonNullValue.toString(),
-                        isEquiv = false)
+                        isEquiv = false
+                    )
                 }
             }.flatten()
             .includeAnnotations()
@@ -135,7 +134,8 @@ class EquivalenceTests {
                     EquivTestCase(
                         left = left.toString(),
                         right = right.toString(),
-                        isEquiv = left.type == right.type)
+                        isEquiv = left.type == right.type
+                    )
                 }
             }.flatten()
             .includeAnnotations()
@@ -149,16 +149,19 @@ class EquivalenceTests {
             EquivTestCase(
                 "true",
                 "true",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "false",
                 "false",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "true",
                 "false",
-                isEquiv = false)
-            ).includeAnnotations()
+                isEquiv = false
+            )
+        ).includeAnnotations()
     }
     @ParameterizedTest
     @ArgumentsSource(IntEquivalenceTestsArgumentsProvider::class)
@@ -168,11 +171,13 @@ class EquivalenceTests {
             EquivTestCase(
                 "0",
                 "0",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "1",
                 "2",
-                isEquiv = false)
+                isEquiv = false
+            )
         ).includeAnnotations()
     }
 
@@ -185,44 +190,54 @@ class EquivalenceTests {
             EquivTestCase(
                 "0.12e4",
                 "0.12e4",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "0.12e4",
                 "0.23e4",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "0e0",
                 "0e0",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "0e0",
                 "-0e0",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "nan",
                 "nan",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "+inf",
                 "+inf",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "-inf",
                 "-inf",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "nan",
                 "+inf",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "nan",
                 "-inf",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "+inf",
                 "-inf",
-                isEquiv = false)
-            ).includeAnnotations()
+                isEquiv = false
+            )
+        ).includeAnnotations()
     }
 
     @ParameterizedTest
@@ -233,24 +248,29 @@ class EquivalenceTests {
             EquivTestCase(
                 "0.0",
                 "0.0",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "1.0",
                 "1.0",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "0.0",
                 "-0.0",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "1.0",
                 "1.00",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "0.0",
                 "0.00",
-                isEquiv = false)
-            ).includeAnnotations()
+                isEquiv = false
+            )
+        ).includeAnnotations()
     }
 
     @ParameterizedTest
@@ -261,12 +281,14 @@ class EquivalenceTests {
             EquivTestCase(
                 "\"some string\"",
                 "\"some string\"",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "\"some string\"",
                 "\"another string\"",
-                isEquiv = false)
-            ).includeAnnotations()
+                isEquiv = false
+            )
+        ).includeAnnotations()
     }
 
     @ParameterizedTest
@@ -277,11 +299,13 @@ class EquivalenceTests {
             EquivTestCase(
                 "'some symbol'",
                 "'some symbol'",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "'some symbol'",
                 "'another symbol'",
-                isEquiv = false)
+                isEquiv = false
+            )
         ).includeAnnotations()
     }
 
@@ -293,19 +317,23 @@ class EquivalenceTests {
             EquivTestCase(
                 "{{}}",
                 "{{}}",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{{}}",
                 "{{ VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE= }}",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "{{ VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE= }}",
                 "{{ VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE= }}",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{{ VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE= }}",
                 "{{ TWFrZSBpdCBzbyE= }}",
-                isEquiv = false)
+                isEquiv = false
+            )
         ).includeAnnotations()
     }
 
@@ -316,20 +344,24 @@ class EquivalenceTests {
         override fun getParameters(): List<Any> = listOf(
             EquivTestCase(
                 "{{ \"\" }}",
-                "{{ \"\" }}" ,
-                isEquiv = true),
+                "{{ \"\" }}",
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{{ \"\" }}",
-                "{{ \"A non-empty CLOB.\" }}" ,
-                isEquiv = false),
+                "{{ \"A non-empty CLOB.\" }}",
+                isEquiv = false
+            ),
             EquivTestCase(
                 "{{ \"This is a CLOB of text.\" }}",
-                "{{ \"This is a CLOB of text.\" }}" ,
-                isEquiv = true),
+                "{{ \"This is a CLOB of text.\" }}",
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{{ \"This is a CLOB of text.\" }}",
-                "{{ \"This is a another CLOB of text.\" }}" ,
-                isEquiv = false)
+                "{{ \"This is a another CLOB of text.\" }}",
+                isEquiv = false
+            )
         ).includeAnnotations()
     }
 
@@ -342,37 +374,45 @@ class EquivalenceTests {
             EquivTestCase(
                 "2001T",
                 "2001T",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "2001T",
                 "3001T",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "2001T",
                 "2001-01T",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "2001-01T",
                 "2001-01T",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "2001-01T",
                 "2001-02T",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "2001-01-01T23:59:59Z",
                 "2001-01-01T23:59:59Z",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "2001-01-01T23:59:58Z",
                 "2001-01-01T23:59:59Z",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 // These values do represent the same instant in time but they are not equivalent since
                 // the offset is specified differently.
                 "2001-01-01T10:00:00-08:00",
                 "2001-01-01T18:00:00Z",
-                isEquiv = false)
+                isEquiv = false
+            )
         ).includeAnnotations()
     }
 
@@ -384,47 +424,58 @@ class EquivalenceTests {
             EquivTestCase(
                 "{}",
                 "{}",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{ a: 1 }",
                 "{ a: 1 }",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{ a: 1 }",
                 "{ a: 2 }",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "{ a: 1, a: 1 }",
                 "{ a: 1, a: 1 }",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{ a: 1 }",
                 "{ a: 1, a: 1 }",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "{ a: 1, a: 1 }",
                 "{ a: 1, a: 2 }",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "{ a: 1, a: 1 }",
                 "{ a: 2, a: 1 }",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "{ a: 1, a: 2 }",
                 "{ a: 1, a: 2 }",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{ a: 1, a: 2 }",
                 "{ a: 2, a: 1 }",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{ a: 1, b: 2 }",
                 "{ b: 2, a: 1 }",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "{ a: 1, b: 2, b: 3 }",
                 "{ b: 3, b: 2, a: 1 }",
-                isEquiv = true)
+                isEquiv = true
+            )
         ).includeAnnotations()
     }
 
@@ -436,31 +487,38 @@ class EquivalenceTests {
             EquivTestCase(
                 "[]",
                 "[]",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "[1]",
                 "[1,1]",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "[1]",
                 "[2]",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "[1]",
                 "[1]",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "[1,1]",
                 "[1,1]",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "[1,2]",
                 "[2,1]",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "[(1)]",
                 "[(1)]",
-                isEquiv = true)
+                isEquiv = true
+            )
         ).includeAnnotations()
     }
 
@@ -472,33 +530,38 @@ class EquivalenceTests {
             EquivTestCase(
                 "()",
                 "()",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "(1)",
                 "(1 1)",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "(1)",
                 "(2)",
-                isEquiv = false),
+                isEquiv = false
+            ),
             EquivTestCase(
                 "(1)",
                 "(1)",
-                isEquiv = true),
+                isEquiv = true
+            ),
             EquivTestCase(
                 "(1 1)",
-                "(1 1)" ,
-                isEquiv = true),
+                "(1 1)",
+                isEquiv = true
+            ),
             EquivTestCase(
                 "(1 2)",
-                "(2 1)" ,
-                isEquiv = false),
+                "(2 1)",
+                isEquiv = false
+            ),
             EquivTestCase(
                 "([1])",
-                "([1])" ,
-                isEquiv = true)
+                "([1])",
+                isEquiv = true
+            )
         ).includeAnnotations()
     }
-
 }
-

--- a/test/com/amazon/ionelement/IonElementExtensionsTests.kt
+++ b/test/com/amazon/ionelement/IonElementExtensionsTests.kt
@@ -3,19 +3,16 @@ package com.amazon.ionelement
 import com.amazon.ion.Decimal
 import com.amazon.ionelement.api.*
 import com.amazon.ionelement.util.ArgumentsProviderBase
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ArgumentsProvider
-import org.junit.jupiter.params.provider.ArgumentsSource
-import org.junit.jupiter.params.provider.MethodSource
-import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
 
-class IonElementExtensionsTests: ArgumentsProviderBase() {
+class IonElementExtensionsTests : ArgumentsProviderBase() {
 
     override fun getParameters(): List<IonElement> = listOf(
         ionInt(1),

--- a/test/com/amazon/ionelement/IonElementLoaderTests.kt
+++ b/test/com/amazon/ionelement/IonElementLoaderTests.kt
@@ -15,18 +15,9 @@
 
 package com.amazon.ionelement
 
-import com.amazon.ionelement.api.createIonElementLoader
-import com.amazon.ionelement.api.ionBool
-import com.amazon.ionelement.api.ionInt
-import com.amazon.ionelement.api.ionListOf
-import com.amazon.ionelement.api.ionString
-import com.amazon.ionelement.api.ionStructOf
-import com.amazon.ionelement.api.ionTimestamp
-import com.amazon.ionelement.api.loadSingleElement
-import com.amazon.ionelement.api.toIonElement
-import com.amazon.ionelement.api.toIonValue
-import com.amazon.ionelement.util.ION
+import com.amazon.ionelement.api.*
 import com.amazon.ionelement.util.INCLUDE_LOCATION_META
+import com.amazon.ionelement.util.ION
 import com.amazon.ionelement.util.IonElementLoaderTestCase
 import com.amazon.ionelement.util.convertToString
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -81,7 +72,9 @@ class IonElementLoaderTests {
                 ionStructOf(
                     "foo" to ionInt(1),
                     "bar" to ionInt(2),
-                    "bat" to ionInt(3))))
+                    "bat" to ionInt(3)
+                )
+            )
+        )
     }
 }
-

--- a/test/com/amazon/ionelement/StructIonElementTests.kt
+++ b/test/com/amazon/ionelement/StructIonElementTests.kt
@@ -15,8 +15,8 @@
 
 package com.amazon.ionelement
 
-import com.amazon.ionelement.api.IonElementException
 import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.IonElementException
 import com.amazon.ionelement.api.StructField
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.loadSingleElement
@@ -56,31 +56,43 @@ class StructIonElementTests {
 
     @Test
     fun get() {
-        assertEquals(ionInt(1), struct["a"],
-            "value is returned when field is present")
+        assertEquals(
+            ionInt(1), struct["a"],
+            "value is returned when field is present"
+        )
 
         val b1 = struct["b"]
-        assertTrue(listOf(ionInt(2), ionInt(3)).any { it == b1 },
-            "any value of the b field is returned (duplicate field name)")
+        assertTrue(
+            listOf(ionInt(2), ionInt(3)).any { it == b1 },
+            "any value of the b field is returned (duplicate field name)"
+        )
 
         val ex = assertThrows<IonElementException>("exception is thrown when field is not present") {
             struct["z"]
         }
-        assertTrue(ex.message!!.contains("'z'"),
-            "Exception message must contain the missing field")
+        assertTrue(
+            ex.message!!.contains("'z'"),
+            "Exception message must contain the missing field"
+        )
     }
 
     @Test
     fun getOptional() {
-        assertEquals(ionInt(1), struct.getOptional("a"),
-            "value is returned when field is present")
+        assertEquals(
+            ionInt(1), struct.getOptional("a"),
+            "value is returned when field is present"
+        )
 
         val b2 = struct.getOptional("b")
-        assertTrue(listOf(ionInt(1), ionInt(2)).any { it == b2 },
-            "any value of the b field is returned (duplicate field name)")
+        assertTrue(
+            listOf(ionInt(1), ionInt(2)).any { it == b2 },
+            "any value of the b field is returned (duplicate field name)"
+        )
 
-        assertNull(struct.getOptional("z"),
-            "null is returned when the field is not present.")
+        assertNull(
+            struct.getOptional("z"),
+            "null is returned when the field is not present."
+        )
     }
 
     @Test
@@ -93,5 +105,4 @@ class StructIonElementTests {
     private fun Iterable<StructField>.assertHasField(expectedName: String, expectedValue: IonElement) {
         assertTrue(this.any { (name, value) -> name == expectedName && value == expectedValue }, "Must have field '$expectedName'")
     }
-
 }

--- a/test/com/amazon/ionelement/ToIonValueTests.kt
+++ b/test/com/amazon/ionelement/ToIonValueTests.kt
@@ -3,8 +3,8 @@ package com.amazon.ionelement
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.toIonElement
 import com.amazon.ionelement.api.toIonValue
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class ToIonValueTests {
 
@@ -19,6 +19,6 @@ class ToIonValueTests {
         val element = ionValue.toIonElement()
         val ionList = ion.newList(element.toIonValue(ion))
 
-        assertEquals(ion.singleValue("[1]"), ionList);
+        assertEquals(ion.singleValue("[1]"), ionList)
     }
 }

--- a/test/com/amazon/ionelement/demos/kotlin/AnyElementAccessorsDemo.kt
+++ b/test/com/amazon/ionelement/demos/kotlin/AnyElementAccessorsDemo.kt
@@ -26,7 +26,7 @@ import com.amazon.ionelement.util.TOP_LEVEL_STRUCTS_ION_TEXT
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class IonElementExtractionInKotlinTests {
+class AnyElementAccessorsDemo {
 
     /**
      * Demonstrates data extraction with non-nullable data type accessors.
@@ -46,9 +46,11 @@ class IonElementExtractionInKotlinTests {
                                 order.asStruct().run {
                                     Order(
                                         get("customerId").longValue,
-                                        get("state").textValue)
+                                        get("state").textValue
+                                    )
                                 }
-                            })
+                            }
+                        )
                     }
                 }
         }.asSequence().toList()
@@ -63,14 +65,16 @@ class IonElementExtractionInKotlinTests {
                 listOf(
                     Order(123, "WA"),
                     Order(456, "HI")
-                )),
+                )
+            ),
             StockItem(
                 "<unknown name>", Decimal.valueOf("23.45"), 20,
                 listOf(
                     Order(234, "VA"),
                     Order(567, "MI")
-                )))
-
+                )
+            )
+        )
 
         assertEquals(expectedTestCases, stockItems)
     }

--- a/test/com/amazon/ionelement/demos/kotlin/NarrowingDemo.kt
+++ b/test/com/amazon/ionelement/demos/kotlin/NarrowingDemo.kt
@@ -6,10 +6,10 @@ import com.amazon.ionelement.api.StringElement
 import com.amazon.ionelement.api.TextElement
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
 
 class NarrowingDemo {
     sealed class ValueContainer {
@@ -32,7 +32,7 @@ class NarrowingDemo {
     }
 
     class Env(val elem: IonElement)
-    private inline fun <reified T: IonElement> List<Env>.extractNarrowValue() =
+    private inline fun <reified T : IonElement> List<Env>.extractNarrowValue() =
         first().let { it.elem as T }
 
     @Test

--- a/test/com/amazon/ionelement/demos/kotlin/UnexpectedTypesDemo.kt
+++ b/test/com/amazon/ionelement/demos/kotlin/UnexpectedTypesDemo.kt
@@ -35,7 +35,8 @@ class UnexpectedTypesDemo {
     data class TestCase(
         val ionText: String,
         val expectedIonLocation: IonLocation,
-        val block: (AnyElement) -> Unit)
+        val block: (AnyElement) -> Unit
+    )
 
     @ParameterizedTest
     @MethodSource("parametersForIonElectrolyteExceptionTest")
@@ -60,5 +61,4 @@ class UnexpectedTypesDemo {
             }
         )
     }
-
 }

--- a/test/com/amazon/ionelement/util/ArgumentsProviderBase.kt
+++ b/test/com/amazon/ionelement/util/ArgumentsProviderBase.kt
@@ -15,10 +15,10 @@
 
 package com.amazon.ionelement.util
 
+import java.util.stream.Stream
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
-import java.util.stream.Stream
 
 /**
  * Reduces some of the boilerplate associated with the style of parameterized testing frequently
@@ -38,6 +38,4 @@ abstract class ArgumentsProviderBase : ArgumentsProvider {
     override fun provideArguments(extensionContext: ExtensionContext): Stream<out Arguments>? {
         return getParameters().map { Arguments.of(it) }.stream()
     }
-
 }
-

--- a/test/com/amazon/ionelement/util/Constants.kt
+++ b/test/com/amazon/ionelement/util/Constants.kt
@@ -18,7 +18,6 @@ package com.amazon.ionelement.util
 
 import com.amazon.ion.Decimal
 
-
 @JvmField
 val TOP_LEVEL_STRUCTS_ION_TEXT = """
 stock_item::{
@@ -42,4 +41,3 @@ stock_item::{ // stock item has no name
 
 data class StockItem(val name: String, val price: Decimal, val countInStock: Long, val orders: List<Order>)
 data class Order(val customerId: Long, val state: String)
-

--- a/test/com/amazon/ionelement/util/IonElementLoaderTestCase.kt
+++ b/test/com/amazon/ionelement/util/IonElementLoaderTestCase.kt
@@ -18,4 +18,3 @@ package com.amazon.ionelement.util
 import com.amazon.ionelement.api.IonElement
 
 data class IonElementLoaderTestCase(val textIon: String, val expectedElement: IonElement)
-

--- a/test/com/amazon/ionelement/util/TestUtils.kt
+++ b/test/com/amazon/ionelement/util/TestUtils.kt
@@ -17,7 +17,6 @@
 package com.amazon.ionelement.util
 import com.amazon.ion.IonValue
 import com.amazon.ion.system.IonSystemBuilder
-
 import com.amazon.ionelement.api.IonElementLoaderOptions
 
 @JvmField

--- a/test/com/amazon/ionelement/util/randomElement.kt
+++ b/test/com/amazon/ionelement/util/randomElement.kt
@@ -62,7 +62,7 @@ fun randomIonElement(): AnyElement {
             }
             // Generate a scalar value
             else -> {
-                when(random.nextInt(8)) {
+                when (random.nextInt(8)) {
                     0 -> ionNull(ElementType.values()[random.nextInt(ElementType.values().size)])
                     1 -> ionBool(random.nextBoolean())
                     2 -> ionInt(random.nextLong())


### PR DESCRIPTION

**Issue #, if available:**

None

**Description of changes:**

Adds [ktlint](https://github.com/pinterest/ktlint) and [Kotlin/binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator) as Gradle build checks.

This PR is large, but I've split each change into a separate commit so that you can view them independently if you like.

There's really only three files that need to be reviewed—`README.md`, `.editorconfig`, and `build.gradle`. All of the other changes are automated changes.

There are two _new_ files that you may not be familiar with.

**`api/IonElement.api`** – this is an automatically generated file that lists the binary APIs of this library. There is now an `apiCheck` Gradle task that will compare the binary API of the build against the binary API that is stored in this file. If there is a difference, the `apiCheck` task will fail. If the API change is intentional, run `apiDump` to regenerate the api file. Why add this? First, it means that changes to the _binary_ API cannot be introduced by accident. (It does not protect against source-incompatible changes, such as changes to reified inline functions.) Second, we can look at the diff of this file when preparing a release. If the file has no changes, it's _probably_ a patch release. If the file has only additive changes, it's a minor version. Anything else is a new major version.
**`.editorconfig`** – This file defines style settings. It is supported in most IDEs, including IntelliJ, and Ktlint uses it for some configuration as well. Here, we are using it to require newlines at the end of every file, we're making IntelliJ and Ktlint have consistent behavior regarding ordering of imports and whether wildcard imports are allowed, and we're disabling one Ktlint rule for the test files. See https://editorconfig.org/ for more info about `.editorconfig` files in general.




_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

