### PR TITLE
Removes some extension functions that are not a cohesive part of this library

### DIFF
--- a/api/IonElement.api
+++ b/api/IonElement.api
@@ -357,14 +357,6 @@ public class com/amazon/ionelement/api/IonElementException : java/lang/Error {
 	public final fun getLocation ()Lcom/amazon/ionelement/api/IonLocation;
 }
 
-public final class com/amazon/ionelement/api/IonElementExtensionsKt {
-	public static final fun getHead (Lcom/amazon/ionelement/api/SeqElement;)Lcom/amazon/ionelement/api/AnyElement;
-	public static final fun getHead (Ljava/util/List;)Lcom/amazon/ionelement/api/AnyElement;
-	public static final fun getTag (Lcom/amazon/ionelement/api/SeqElement;)Ljava/lang/String;
-	public static final fun getTail (Lcom/amazon/ionelement/api/SeqElement;)Ljava/util/List;
-	public static final fun getTail (Ljava/util/List;)Ljava/util/List;
-}
-
 public abstract interface class com/amazon/ionelement/api/IonElementLoader {
 	public abstract fun loadAllElements (Lcom/amazon/ion/IonReader;)Ljava/lang/Iterable;
 	public abstract fun loadAllElements (Ljava/lang/String;)Ljava/lang/Iterable;

--- a/src/com/amazon/ionelement/impl/IonElementExtensions.kt
+++ b/src/com/amazon/ionelement/impl/IonElementExtensions.kt
@@ -13,7 +13,9 @@
  *  permissions and limitations under the License.
  */
 
-package com.amazon.ionelement.api
+package com.amazon.ionelement.impl
+
+import com.amazon.ionelement.api.*
 
 /** Returns a shallow copy of the current node with the specified additional annotations. */
 internal inline fun <reified T : IonElement> T._withAnnotations(vararg additionalAnnotations: String): T =
@@ -58,40 +60,3 @@ internal inline fun <reified T : IonElement> T._withoutMetas(): T =
         metas.isEmpty() -> this
         else -> copy(metas = emptyMetaContainer(), annotations = annotations) as T
     }
-
-/**
- * Returns the string representation of the symbol in the first element of this container.
- *
- * If the first element is not a symbol or this container has no elements, throws [IonElementException],
- */
-public val SeqElement.tag: String get() = this.head.symbolValue
-
-/**
- * Returns the first element of this container.
- *
- * If this container has no elements, throws [IonElementException].
- */
-public val SeqElement.head: AnyElement
-    get() =
-        when (this.size) {
-            0 -> constraintError(this, "Cannot get head of empty container")
-            else -> this.values.first()
-        }
-
-/**
- * Returns a sub-list containing all elements of this container except the first.
- *
- * If this container has no elements, throws [IonElementException].
- */
-public val SeqElement.tail: List<AnyElement> get() =
-    when (this.size) {
-        0 -> constraintError(this, "Cannot get tail of empty container")
-        else -> this.values.subList(1, this.size)
-    }
-
-/** Returns the first element. */
-public val List<AnyElement>.head: AnyElement
-    get() = this.first()
-
-/** Returns a copy of the list with the first element removed. */
-public val List<AnyElement>.tail: List<AnyElement> get() = this.subList(1, this.size)

--- a/test/com/amazon/ionelement/impl/IonElementExtensionsTests.kt
+++ b/test/com/amazon/ionelement/impl/IonElementExtensionsTests.kt
@@ -1,4 +1,4 @@
-package com.amazon.ionelement
+package com.amazon.ionelement.impl
 
 import com.amazon.ion.Decimal
 import com.amazon.ionelement.api.*
@@ -7,8 +7,6 @@ import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 
@@ -127,21 +125,5 @@ class IonElementExtensionsTests : ArgumentsProviderBase() {
         // also check that annotations haven't been lost
         assertEquals(1, noMetas.annotations.size)
         assertTrue(noMetas.annotations.contains("foo"))
-    }
-
-    @Test
-    fun head() {
-        val sexp = loadSingleElement("(1 2 3)").asSexp()
-        assertEquals(ionInt(1).asAnyElement(), sexp.head)
-    }
-
-    @Test
-    fun tail() {
-        val sexp = loadSingleElement("(1 2 3)").asSexp()
-
-        assertEquals(listOf<IonElement>(ionInt(2), ionInt(3)), sexp.tail)
-        assertEquals(listOf<IonElement>(ionInt(3)), sexp.tail.tail)
-        assertEquals(listOf(), sexp.tail.tail.tail)
-        assertThrows<IllegalArgumentException> { sexp.tail.tail.tail.tail }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

The Ion Element Kotlin library includes some extension functions that are not specific to Ion. The concept of `tag`, `head`, and `tail` are not specific to Ion, and are not cohesive with the rest of this library.

Clients can still re-implement these extension functions if necessary. However, they shouldn't need to because there are KotlinStdlib functions (`first()` and `drop(n: Int)`) that can accomplish the same thing. For example:

```kotlin
// To assume and get the symbol text of the first element of a sequence (aka the "tag")
val tag = mySeqElement.values.first().symbolValue

// To get the head of a sequence
val head = mySeqElement.values.first()

// To get the tail of a sequence
val tail = mySequence.values.drop(1)

// To get the head of a List<AnyElement>
val headOfList = anyElementList.first()

// To get the tail of a List<AnyElement>
val tailOfList = anyElementList.drop(1)
```



_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

